### PR TITLE
Mind shattering rendering system (V4)

### DIFF
--- a/GJ2022.Tests/RendererTests/RenderBatchTests/TestRenderBatches.cs
+++ b/GJ2022.Tests/RendererTests/RenderBatchTests/TestRenderBatches.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.RenderSystems;
+﻿using GJ2022.Rendering.Models;
+using GJ2022.Rendering.RenderSystems;
 using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.Textures;
 using GJ2022.Utility.MathConstructs;
@@ -19,9 +20,11 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
 
     }
 
-    public class TestRenderable : IInstanceRenderable
+    public class TestRenderable : IStandardRenderable
     {
         private int sample;
+
+        public RenderSystem<IStandardRenderable, InstanceRenderSystem> RenderSystem => InstanceRenderSystem.Singleton;
 
         public Vector GetInstancePosition() { return new Vector(3); }
 
@@ -30,12 +33,12 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
             return new Colour();
         }
 
-        public void SetRenderableBatchIndex(RenderBatchSet associatedSet, int index)
+        public void SetRenderableBatchIndex(object associatedSet, int index)
         {
             sample = index;
         }
 
-        public int GetRenderableBatchIndex(RenderBatchSet associatedSet)
+        public int GetRenderableBatchIndex(object associatedSet)
         {
             return sample;
         }
@@ -43,6 +46,26 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
         public Vector GetInstanceScale()
         {
             return new Vector(2, 1, 1);
+        }
+
+        public RendererTextureData GetRendererTextureData()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Model GetModel()
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint GetTextureUint()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Vector GetPosition()
+        {
+            throw new NotImplementedException();
         }
     }
 
@@ -55,9 +78,9 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
         [TestMethod]
         public void TestBasicAdding()
         {
-            RenderBatchSet set = new RenderBatchSet(sampleTextureData);
+            RenderBatchSet<IStandardRenderable, InstanceRenderSystem> set = new RenderBatchSet<IStandardRenderable, InstanceRenderSystem>(sampleTextureData, 0, new int[] { });
             Assert.AreEqual(0, set.renderElements, "Set should contain no render elements");
-            IInstanceRenderable testRenderable = new TestRenderable();
+            IStandardRenderable testRenderable = new TestRenderable();
             set.AddToBatch(testRenderable, sampleTextureData);
             Assert.AreEqual(1, set.renderElements, "Set should contain 1 render elements");
         }
@@ -65,12 +88,12 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
         [TestMethod]
         public void TestBasicRemoving()
         {
-            RenderBatchSet set = new RenderBatchSet(sampleTextureData);
+            RenderBatchSet<IStandardRenderable, InstanceRenderSystem> set = new RenderBatchSet<IStandardRenderable, InstanceRenderSystem>(sampleTextureData, 0, new int[] { });
             Assert.AreEqual(0, set.renderElements, "Set should contain no render elements");
-            IInstanceRenderable testRenderable = new TestRenderable();
+            IStandardRenderable testRenderable = new TestRenderable();
             set.AddToBatch(testRenderable, sampleTextureData);
             Assert.AreEqual(1, set.renderElements, "Set should contain 1 render elements");
-            IInstanceRenderable testRenderable2 = new TestRenderable();
+            IStandardRenderable testRenderable2 = new TestRenderable();
             set.AddToBatch(testRenderable2, sampleTextureData);
             Assert.AreEqual(2, set.renderElements, "Set should contain 2 render elements");
             Assert.AreEqual(testRenderable, set.renderBatches[0].instanceRenderables[0], "Instance 1 should be stored at 0");
@@ -83,12 +106,12 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
         [TestMethod]
         public void TestClearing()
         {
-            RenderBatchSet set = new RenderBatchSet(sampleTextureData);
+            RenderBatchSet<IStandardRenderable, InstanceRenderSystem> set = new RenderBatchSet<IStandardRenderable, InstanceRenderSystem>(sampleTextureData, 0, new int[] { });
             Assert.AreEqual(0, set.renderElements, "Set should contain no render elements");
-            IInstanceRenderable testRenderable = new TestRenderable();
+            IStandardRenderable testRenderable = new TestRenderable();
             set.AddToBatch(testRenderable, sampleTextureData);
             Assert.AreEqual(1, set.renderElements, "Set should contain 1 render elements");
-            IInstanceRenderable testRenderable2 = new TestRenderable();
+            IStandardRenderable testRenderable2 = new TestRenderable();
             set.AddToBatch(testRenderable2, sampleTextureData);
             Assert.AreEqual(2, set.renderElements, "Set should contain 2 render elements");
             set.RemoveFromBatch(testRenderable);
@@ -100,32 +123,32 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
         [TestMethod]
         public void TestBatchOverflowing()
         {
-            RenderBatchSet set = new RenderBatchSet(sampleTextureData);
+            RenderBatchSet<IStandardRenderable, InstanceRenderSystem> set = new RenderBatchSet<IStandardRenderable, InstanceRenderSystem>(sampleTextureData, 0, new int[] { });
 
             //Fill with 25000 elements
 
             //THIS IS REUSED, USING THIS WILL CAUSE PROBLEMS AND IS NOT THE POINT OF THIS TEST
-            IInstanceRenderable reusableTestRenderable = new TestRenderable();
+            IStandardRenderable reusableTestRenderable = new TestRenderable();
 
-            for (int i = 0; i < RenderBatch.MAX_BATCH_SIZE; i++)
+            for (int i = 0; i < RenderBatch<IStandardRenderable, InstanceRenderSystem>.MAX_BATCH_SIZE; i++)
             {
                 set.AddToBatch(reusableTestRenderable, sampleTextureData);
             }
 
-            Assert.AreEqual(RenderBatch.MAX_BATCH_SIZE, set.renderElements, $"There should be {RenderBatch.MAX_BATCH_SIZE} items inside the render batch.");
+            Assert.AreEqual(RenderBatch<IStandardRenderable, InstanceRenderSystem>.MAX_BATCH_SIZE, set.renderElements, $"There should be {RenderBatch<IStandardRenderable, InstanceRenderSystem>.MAX_BATCH_SIZE} items inside the render batch.");
             Assert.AreEqual(1, set.renderBatches.Count, "There should only be 1 render batch");
 
             //Cause an overflow
-            IInstanceRenderable overflowingElement = new TestRenderable();
+            IStandardRenderable overflowingElement = new TestRenderable();
             set.AddToBatch(overflowingElement, sampleTextureData);
 
-            Assert.AreEqual(RenderBatch.MAX_BATCH_SIZE + 1, set.renderElements, $"There should be {RenderBatch.MAX_BATCH_SIZE + 1} items inside the render batch.");
+            Assert.AreEqual(RenderBatch<IStandardRenderable, InstanceRenderSystem>.MAX_BATCH_SIZE + 1, set.renderElements, $"There should be {RenderBatch<IStandardRenderable, InstanceRenderSystem>.MAX_BATCH_SIZE + 1} items inside the render batch.");
             Assert.AreEqual(2, set.renderBatches.Count, "Due to an overflow, there should be 2 render batches");
 
             //Remove it
             set.RemoveFromBatch(overflowingElement);
 
-            Assert.AreEqual(RenderBatch.MAX_BATCH_SIZE, set.renderElements, "Testing correct batch size");
+            Assert.AreEqual(RenderBatch<IStandardRenderable, InstanceRenderSystem>.MAX_BATCH_SIZE, set.renderElements, "Testing correct batch size");
             Assert.AreEqual(1, set.renderBatches.Count, "Testing correct batch count: Extra batch should have been deleted");
 
         }

--- a/GJ2022/Entities/Background/Background.cs
+++ b/GJ2022/Entities/Background/Background.cs
@@ -17,7 +17,7 @@ namespace GJ2022.Entities.Background
 
         public override ModelData ModelData { get; set; } = QuadModelData.Singleton;
 
-        public RenderSystem<IBackgroundRenderable, BackgroundRenderSystem> TargetRenderSystem => BackgroundRenderSystem.Singleton;
+        public RenderSystem<IBackgroundRenderable, BackgroundRenderSystem> RenderSystem => BackgroundRenderSystem.Singleton;
 
         public BackgroundEntity(Vector position) : base(position)
         { }
@@ -51,6 +51,11 @@ namespace GJ2022.Entities.Background
                 return renderableBatchIndex[associatedSet];
             else
                 return -1;
+        }
+
+        public RendererTextureData GetRendererTextureData()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/GJ2022/Entities/Background/Background.cs
+++ b/GJ2022/Entities/Background/Background.cs
@@ -22,11 +22,6 @@ namespace GJ2022.Entities.Background
         public BackgroundEntity(Vector position) : base(position)
         { }
 
-        public override RendererTextureData GetRendererTexture()
-        {
-            return TextureCache.GetTexture(TextureCache.ERROR_ICON_STATE);
-        }
-
         /// <summary>
         /// Instance renderable stuff
         /// </summary>
@@ -55,7 +50,7 @@ namespace GJ2022.Entities.Background
 
         public RendererTextureData GetRendererTextureData()
         {
-            throw new NotImplementedException();
+            return TextureCache.GetTexture(TextureCache.ERROR_ICON_STATE);
         }
     }
 }

--- a/GJ2022/Entities/Background/Background.cs
+++ b/GJ2022/Entities/Background/Background.cs
@@ -12,10 +12,12 @@ using GJ2022.Utility.MathConstructs;
 
 namespace GJ2022.Entities.Background
 {
-    class BackgroundEntity : Entity, IInstanceRenderable
+    class BackgroundEntity : Entity, IBackgroundRenderable
     {
 
         public override ModelData ModelData { get; set; } = QuadModelData.Singleton;
+
+        public RenderSystem<IBackgroundRenderable, BackgroundRenderSystem> TargetRenderSystem => BackgroundRenderSystem.Singleton;
 
         public BackgroundEntity(Vector position) : base(position)
         { }
@@ -29,9 +31,9 @@ namespace GJ2022.Entities.Background
         /// Instance renderable stuff
         /// </summary>
 
-        private Dictionary<RenderBatchSet, int> renderableBatchIndex = new Dictionary<RenderBatchSet, int>();
+        private Dictionary<object, int> renderableBatchIndex = new Dictionary<object, int>();
 
-        public void SetRenderableBatchIndex(RenderBatchSet associatedSet, int index)
+        public void SetRenderableBatchIndex(object associatedSet, int index)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
                 renderableBatchIndex[associatedSet] = index;
@@ -43,22 +45,12 @@ namespace GJ2022.Entities.Background
         /// Returns the renderable batch index in the provided set.
         /// Returns -1 if failed.
         /// </summary>
-        public int GetRenderableBatchIndex(RenderBatchSet associatedSet)
+        public int GetRenderableBatchIndex(object associatedSet)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
                 return renderableBatchIndex[associatedSet];
             else
                 return -1;
-        }
-
-        public Vector GetInstancePosition()
-        {
-            return position;
-        }
-
-        public Vector GetInstanceScale()
-        {
-            return new Vector(2, 1, 1);
         }
     }
 }

--- a/GJ2022/Entities/Debug/DebugEntity.cs
+++ b/GJ2022/Entities/Debug/DebugEntity.cs
@@ -18,7 +18,7 @@ namespace GJ2022.Entities.Debug
     /// <summary>
     /// Debug entity, add whatever you want to this for testing.
     /// </summary>
-    public class DebugEntity : Entity, IInstanceRenderable, IMouseEnter, IMouseExit, IDestroyable
+    public class DebugEntity : Entity, IStandardRenderable, IMouseEnter, IMouseExit, IDestroyable
     {
 
         public override ModelData ModelData { get; set; } = QuadModelData.Singleton;
@@ -31,23 +31,20 @@ namespace GJ2022.Entities.Debug
 
         public float Height => 1.0f;
 
+        public RenderSystem<IStandardRenderable, InstanceRenderSystem> RenderSystem => InstanceRenderSystem.Singleton;
+
         public DebugEntity(Vector position) : base(position)
         {
             MouseCollisionSubsystem.Singleton.StartTracking(this);
-        }
-
-        public override RendererTextureData GetRendererTexture()
-        {
-            return TextureCache.GetTexture(TextureCache.ERROR_ICON_STATE);
         }
 
         /// <summary>
         /// Instance renderable stuff
         /// </summary>
 
-        private Dictionary<RenderBatchSet, int> renderableBatchIndex = new Dictionary<RenderBatchSet, int>();
+        private Dictionary<object, int> renderableBatchIndex = new Dictionary<object, int>();
 
-        public void SetRenderableBatchIndex(RenderBatchSet associatedSet, int index)
+        public void SetRenderableBatchIndex(object associatedSet, int index)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
                 renderableBatchIndex[associatedSet] = index;
@@ -59,7 +56,7 @@ namespace GJ2022.Entities.Debug
         /// Returns the renderable batch index in the provided set.
         /// Returns -1 if failed.
         /// </summary>
-        public int GetRenderableBatchIndex(RenderBatchSet associatedSet)
+        public int GetRenderableBatchIndex(object associatedSet)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
                 return renderableBatchIndex[associatedSet];
@@ -95,6 +92,26 @@ namespace GJ2022.Entities.Debug
         public Vector GetInstanceScale()
         {
             return new Vector(2, 1, 1);
+        }
+
+        public Model GetModel()
+        {
+            return ModelData.model;
+        }
+
+        public uint GetTextureUint()
+        {
+            return GetRendererTextureData().TextureUint;
+        }
+
+        public Vector GetPosition()
+        {
+            return position;
+        }
+
+        public RendererTextureData GetRendererTextureData()
+        {
+            return TextureCache.GetTexture(TextureCache.ERROR_ICON_STATE);
         }
     }
 }

--- a/GJ2022/Entities/StationPart/Hallways/HallwayCross.cs
+++ b/GJ2022/Entities/StationPart/Hallways/HallwayCross.cs
@@ -15,9 +15,5 @@ namespace GJ2022.Entities.StationPart.Hallways
 
         public HallwayCross(Vector position) : base(position) { }
 
-        public override RendererTextureData GetRendererTexture()
-        {
-            return TextureCache.GetTexture(TextureCache.ERROR_ICON_STATE);
-        }
     }
 }

--- a/GJ2022/Entities/StationPart/StationPartEntity.cs
+++ b/GJ2022/Entities/StationPart/StationPartEntity.cs
@@ -1,6 +1,7 @@
 ﻿using GJ2022.Rendering.Models;
 using GJ2022.Rendering.RenderSystems;
 using GJ2022.Rendering.RenderSystems.Interfaces;
+using GJ2022.Rendering.Textures;
 using GJ2022.Utility.MathConstructs;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace GJ2022.Entities.StationPart
 {
-    public abstract class StationPartEntity : Entity, IInstanceRenderable
+    public abstract class StationPartEntity : Entity, IStandardRenderable
     {
 
         public override ModelData ModelData { get; set; } = QuadModelData.Singleton;
@@ -21,12 +22,14 @@ namespace GJ2022.Entities.StationPart
         //Set the relative connection points
         public virtual Vector[] RelativeConnectionPoints { get; protected set; }
 
+        public RenderSystem<IStandardRenderable, InstanceRenderSystem> RenderSystem => InstanceRenderSystem.Singleton;
+
         //Ctor
         public StationPartEntity(Vector position) : base(position) { }
 
-        private Dictionary<RenderBatchSet, int> renderableBatchIndex = new Dictionary<RenderBatchSet, int>();
+        private Dictionary<object, int> renderableBatchIndex = new Dictionary<object, int>();
 
-        public void SetRenderableBatchIndex(RenderBatchSet associatedSet, int index)
+        public void SetRenderableBatchIndex(object associatedSet, int index)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
                 renderableBatchIndex[associatedSet] = index;
@@ -38,7 +41,7 @@ namespace GJ2022.Entities.StationPart
         /// Returns the renderable batch index in the provided set.
         /// Returns -1 if failed.
         /// </summary>
-        public int GetRenderableBatchIndex(RenderBatchSet associatedSet)
+        public int GetRenderableBatchIndex(object associatedSet)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
                 return renderableBatchIndex[associatedSet];
@@ -54,6 +57,26 @@ namespace GJ2022.Entities.StationPart
         public Vector GetInstanceScale()
         {
             return new Vector(2, 3, 1);
+        }
+
+        public Model GetModel()
+        {
+            return ModelData.model;
+        }
+
+        public uint GetTextureUint()
+        {
+            return GetRendererTextureData().TextureUint;
+        }
+
+        public Vector GetPosition()
+        {
+            return position;
+        }
+
+        public RendererTextureData GetRendererTextureData()
+        {
+            return TextureCache.GetTexture(TextureCache.ERROR_ICON_STATE);
         }
     }
 }

--- a/GJ2022/Program.cs
+++ b/GJ2022/Program.cs
@@ -16,6 +16,7 @@ using GJ2022.Entities.StationPart.Hallways;
 
 namespace GJ2022
 {
+
     public class Program
     {
 

--- a/GJ2022/Rendering/Models/ModelData/BlockModelData.cs
+++ b/GJ2022/Rendering/Models/ModelData/BlockModelData.cs
@@ -150,26 +150,5 @@ namespace GJ2022.Rendering.Models
                 });
         }
 
-        /// <summary>
-        /// Get the face we want
-        /// </summary>
-        /*public override RenderableData[] GetModelRenderableData(Renderable renderable)
-        {
-            List<RenderableData> models = new List<RenderableData>();
-            if ((faceFlag & CubeFaceFlags.FACE_ABOVE) == CubeFaceFlags.FACE_ABOVE)
-                models.Add(new RenderableData(shader, topFace, renderable, renderable.GetRendererTexture(CubeFaceFlags.FACE_ABOVE)));
-            if ((faceFlag & CubeFaceFlags.FACE_BELOW) == CubeFaceFlags.FACE_BELOW)
-                models.Add(new RenderableData(shader, bottomFace, renderable, renderable.GetRendererTexture(CubeFaceFlags.FACE_BELOW)));
-            if ((faceFlag & CubeFaceFlags.FACE_FRONT) == CubeFaceFlags.FACE_FRONT)
-                models.Add(new RenderableData(shader, frontFace, renderable, renderable.GetRendererTexture(CubeFaceFlags.FACE_FRONT)));
-            if ((faceFlag & CubeFaceFlags.FACE_BACK) == CubeFaceFlags.FACE_BACK)
-                models.Add(new RenderableData(shader, backFace, renderable, renderable.GetRendererTexture(CubeFaceFlags.FACE_BACK)));
-            if ((faceFlag & CubeFaceFlags.FACE_RIGHT) == CubeFaceFlags.FACE_RIGHT)
-                models.Add(new RenderableData(shader, rightFace, renderable, renderable.GetRendererTexture(CubeFaceFlags.FACE_RIGHT)));
-            if ((faceFlag & CubeFaceFlags.FACE_LEFT) == CubeFaceFlags.FACE_LEFT)
-                models.Add(new RenderableData(shader, leftFace, renderable, renderable.GetRendererTexture(CubeFaceFlags.FACE_LEFT)));
-            return models.ToArray();
-        }*/
-
     }
 }

--- a/GJ2022/Rendering/Models/ModelData/ModelData.cs
+++ b/GJ2022/Rendering/Models/ModelData/ModelData.cs
@@ -21,14 +21,5 @@ namespace GJ2022.Rendering.Models
             this.model = model;
         }
 
-        /// <summary>
-        /// Returns a model based on what sides the block is blocked on.
-        /// </summary>
-        /// <param name="renderBlockFlag"></param>
-        public virtual RenderableData[] GetModelRenderableData(Renderable renderable)
-        {
-            return new RenderableData[] { new RenderableData(shader, model, renderable, renderable.GetRendererTexture()) };
-        }
-
     }
 }

--- a/GJ2022/Rendering/Models/ModelData/ModelData.cs
+++ b/GJ2022/Rendering/Models/ModelData/ModelData.cs
@@ -13,7 +13,7 @@ namespace GJ2022.Rendering.Models
 
         protected ShaderSet shader;
 
-        private Model model;
+        public Model model;
 
         public ModelData(ShaderSet shader, Model model)
         {

--- a/GJ2022/Rendering/RenderMaster.cs
+++ b/GJ2022/Rendering/RenderMaster.cs
@@ -3,6 +3,7 @@ using GJ2022.Rendering.RenderSystems;
 using GJ2022.Rendering.RenderSystems.LineRenderer;
 using GJ2022.Utility.MathConstructs;
 using static OpenGL.Gl;
+using GJ2022.Rendering.RenderSystems.Interfaces;
 
 namespace GJ2022.Rendering
 {

--- a/GJ2022/Rendering/RenderSystems/BackgroundRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/BackgroundRenderSystem.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.RenderSystems.Interfaces;
+﻿using GJ2022.Rendering.Models;
+using GJ2022.Rendering.RenderSystems.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,14 +11,42 @@ namespace GJ2022.Rendering.RenderSystems
     class BackgroundRenderSystem : RenderSystem<IBackgroundRenderable, BackgroundRenderSystem>
     {
 
-        public static new BackgroundRenderSystem Singleton;
+        public static BackgroundRenderSystem Singleton;
 
         protected override string SystemShaderName => "backgroundShader";
+
+        protected override int BufferCount => 0;
+
+        protected override int[] BufferWidths { get; } = new int[] { };
+
+        protected override uint[] BufferDataPointsPerInstance { get; } = new uint[] { };
+
+        protected override string[] UniformVariableNames => new string[] {
+            "viewMatrix",
+            "projectionMatrix",
+        };
+
+        protected override unsafe void BindUniformData(RenderBatchSet<IBackgroundRenderable, BackgroundRenderSystem> renderBatchSet)
+        { }
+
+        protected override RenderBatchGroup GetBatchGroup(IBackgroundRenderable renderable)
+        {
+            return new RenderBatchGroup(QuadModelData.Singleton.model, 0);
+        }
 
         protected override void SetSingleton()
         {
             Singleton = this;
         }
 
+        public override void EndRender()
+        {
+            return;
+        }
+
+        public override float[] GetBufferData(IBackgroundRenderable targetItem, int bufferIndex)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/GJ2022/Rendering/RenderSystems/BackgroundRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/BackgroundRenderSystem.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GJ2022.Rendering.RenderSystems.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace GJ2022.Rendering.RenderSystems
 {
-    class BackgroundRenderSystem : InstanceRenderSystem
+    class BackgroundRenderSystem : RenderSystem<IBackgroundRenderable, BackgroundRenderSystem>
     {
 
         public static new BackgroundRenderSystem Singleton;

--- a/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
@@ -1,6 +1,8 @@
 ﻿using GJ2022.Rendering.Models;
 using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.RenderSystems.RenderData;
+using GJ2022.Rendering.Textures;
+using GJ2022.Utility.MathConstructs;
 using System;
 using static OpenGL.Gl;
 
@@ -23,8 +25,6 @@ namespace GJ2022.Rendering.RenderSystems
 
         protected override uint[] BufferDataPointsPerInstance { get; } = new uint[] { 1, 1 };
 
-        protected override bool[] IsInstanceBuffer { get; } = new bool[] { true, true };
-
         protected override RenderBatchGroup GetBatchGroup(IStandardRenderable renderable)
         {
             return new RenderBatchGroup(renderable.GetModel(), renderable.GetTextureUint());
@@ -35,31 +35,32 @@ namespace GJ2022.Rendering.RenderSystems
             Singleton = this;
         }
 
-        public override unsafe float* GetBufferPointer(RenderBatch<IStandardRenderable, InstanceRenderSystem> targetBatch, int index)
-        {
-            switch (index)
-            {
-                case 2:
-                    return &targetBatch.bufferArrays[0];
-            }
-            return null;
-        }
-
         public override void EndRender()
         {
-            throw new NotImplementedException();
+            return;
         }
 
-        protected override uint GetUnmanagedBufferLocation(uint target, RenderBatchGroup targetBatch)
+        public override float[] GetBufferData(IStandardRenderable targetItem, int bufferIndex)
         {
-            switch (target)
+            switch (bufferIndex)
             {
                 case 0:
-                    return targetBatch.Model.VertexBufferObject;
+                    Vector position = targetItem.GetPosition();
+                    return new float[] {
+                        position[0],
+                        position[1],
+                        position[2]
+                    };
                 case 1:
-                    return targetBatch.Model.UvBuffer;
+                    RendererTextureData texData = targetItem.GetRendererTextureData();
+                    return new float[] {
+                        texData.IndexX,
+                        texData.IndexY,
+                        texData.Width,
+                        texData.Height,
+                    };
             }
-            return 0;
+            throw new ArgumentException($"Invalid argument buffer index supplied: buffer supplied {bufferIndex}, maxBuffer: {BufferCount}");
         }
     }
 }

--- a/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
@@ -36,16 +36,6 @@ namespace GJ2022.Rendering.RenderSystems
         private int spriteWidthUniformLocation;
         private int spriteHeightUniformLocation;
 
-        public InstanceRenderSystem() : base()
-        {
-            SetSingleton();
-        }
-
-        protected virtual void SetSingleton()
-        {
-            Singleton = this;
-        }
-
         /// <summary>
         /// Start rendering the models of the renderable provided.
         /// TODO: Make this abstract and make it so not all rendering systems are required to use instance renderables
@@ -65,7 +55,6 @@ namespace GJ2022.Rendering.RenderSystems
         /// </summary>
         private void StartRendering(RenderableData renderableData)
         {
-            //Todo: Convert this to a struct
             RenderBatchGroup renderCacheKey = new RenderBatchGroup(renderableData.shader, renderableData.modelData, renderableData.textureData.TextureUint);
             if (renderCache.ContainsKey(renderCacheKey))
             {

--- a/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
@@ -10,256 +10,56 @@ namespace GJ2022.Rendering.RenderSystems
     /// Rendering system optimised for batch rendering
     /// tons of the same object.
     /// </summary>
-    public class InstanceRenderSystem : RenderSystem
+    public class InstanceRenderSystem : RenderSystem<IStandardRenderable, InstanceRenderSystem>
     {
 
         public static InstanceRenderSystem Singleton;
 
-        //Our shaders are the instance shader set
         protected override string SystemShaderName => "instanceShader";
 
-        //The location of the instance position buffer.
-        //Instance positions are sent via the buffer; the high speed
-        //data transfer to the GPU.
-        private uint instancePositionBuffer;
+        protected override int BufferCount => 2;
 
-        //Location of the instance texture data buffer.
-        private uint instanceTexDataBuffer;
+        protected override int[] BufferWidths { get; } = new int[] { 3, 4 };
 
-        //Location of the instance scale data buffer
-        private uint instanceScaleDataBuffer;
+        protected override uint[] BufferDataPointsPerInstance { get; } = new uint[] { 1, 1 };
 
-        //Location of uniform variables
-        private int viewMatrixUniformLocation;
-        private int projectionMatrixUniformLocation;
-        private int textureSamplerUniformLocation;
-        private int spriteWidthUniformLocation;
-        private int spriteHeightUniformLocation;
+        protected override bool[] IsInstanceBuffer { get; } = new bool[] { true, true };
 
-        /// <summary>
-        /// Start rendering the models of the renderable provided.
-        /// TODO: Make this abstract and make it so not all rendering systems are required to use instance renderables
-        /// </summary>
-        public void StartRendering(Renderable renderable)
+        protected override RenderBatchGroup GetBatchGroup(IStandardRenderable renderable)
         {
-            renderable.IsRendering = true;
-            //Begin rendering
-            foreach (RenderableData renderableData in renderable.ModelData.GetModelRenderableData(renderable))
-            {
-                StartRendering(renderableData);
-            }
+            return new RenderBatchGroup(renderable.GetModel(), renderable.GetTextureUint());
         }
 
-        /// <summary>
-        /// Start rendering a specific renderable data
-        /// </summary>
-        private void StartRendering(RenderableData renderableData)
+        protected override void SetSingleton()
         {
-            RenderBatchGroup renderCacheKey = new RenderBatchGroup(renderableData.shader, renderableData.modelData, renderableData.textureData.TextureUint);
-            if (renderCache.ContainsKey(renderCacheKey))
-            {
-                renderCache[renderCacheKey].AddToBatch(renderableData.attachedRenderable as IInstanceRenderable, renderableData.textureData);
-            }
-            else
-            {
-                RenderBatchSet batchSet = new RenderBatchSet(renderableData.textureData);
-                batchSet.AddToBatch(renderableData.attachedRenderable as IInstanceRenderable, renderableData.textureData);
-                renderCache.Add(renderCacheKey, batchSet);
-            }
+            Singleton = this;
         }
 
-        /// <summary>
-        /// Stop rendering the renderable provided.
-        /// </summary>
-        public void StopRendering(Renderable renderable)
+        public override unsafe float* GetBufferPointer(RenderBatch<IStandardRenderable, InstanceRenderSystem> targetBatch, int index)
         {
-            renderable.IsRendering = false;
-            //Assumes that renderable is actually in the renderCache
-            //:oblivious:
-            foreach (RenderableData renderableData in renderable.ModelData.GetModelRenderableData(renderable))
+            switch (index)
             {
-                StopRendering(renderableData);
+                case 2:
+                    return &targetBatch.bufferArrays[0];
             }
-        }
-
-        public void StopRendering(RenderableData renderableData)
-        {
-            RenderBatchGroup renderCacheKey = new RenderBatchGroup(renderableData.shader, renderableData.modelData, renderableData.textureData.TextureUint);
-            if (!renderCache.ContainsKey(renderCacheKey))
-            {
-                Log.WriteLine($"Failed to locate key in render dict", LogType.WARNING);
-                return;
-            }
-            renderCache[renderCacheKey].RemoveFromBatch(renderableData.attachedRenderable as IInstanceRenderable);
-            if (renderCache[renderCacheKey].renderElements == 0)
-            {
-                renderCache.Remove(renderCacheKey);
-            }
-        }
-
-        public unsafe override void Initialize()
-        {
-
-            //Generate an empty buffer for the instance position buffer
-            instancePositionBuffer = glGenBuffer();
-            glBindBuffer(GL_ARRAY_BUFFER, instancePositionBuffer);
-            //Populate with empty data (We are just reserving the space)
-            glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-
-            //Do the same for instance texture data
-            instanceTexDataBuffer = glGenBuffer();
-            glBindBuffer(GL_ARRAY_BUFFER, instanceTexDataBuffer);
-            //Populate with empty data (We are just reserving the space)
-            glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 4 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-
-            //Do the same for instance scale data
-            instanceScaleDataBuffer = glGenBuffer();
-            glBindBuffer(GL_ARRAY_BUFFER, instanceScaleDataBuffer);
-            //Populate with empty data (We are just reserving the space)
-            glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 2 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-        }
-
-        public unsafe override void BeginRender(Camera mainCamera)
-        {
-            //Attach the shader set
-            glUseProgram(programUint);
-
-            //Attach the shader set so we can grab uniform locations
-            //Link program and use program are required here, not sure what they do exactly.
-            SystemShaders.AttachShaders(programUint);
-            glLinkProgram(programUint);
-
-            //Load the camera's view matrix
-            //Put the matrix into that uniform variable
-            glUniformMatrix4fv(viewMatrixUniformLocation, 1, false, mainCamera.ViewMatrix.GetPointer());
-
-            //Load the camera's projection matrix
-            //Put the matrix into that uniform variable
-            glUniformMatrix4fv(projectionMatrixUniformLocation, 1, false, mainCamera.ProjectionMatrix.GetPointer());
-
-            //Get the uniform locations
-            viewMatrixUniformLocation = glGetUniformLocation(programUint, "viewMatrix");
-            projectionMatrixUniformLocation = glGetUniformLocation(programUint, "projectionMatrix");
-            textureSamplerUniformLocation = glGetUniformLocation(programUint, "textureSampler");
-            spriteWidthUniformLocation = glGetUniformLocation(programUint, "spriteWidth");
-            spriteHeightUniformLocation = glGetUniformLocation(programUint, "spriteHeight");
-            //Detatch the shaders
-            SystemShaders.DetatchShaders(programUint);
-
-        }
-
-        public unsafe override void RenderModels(Camera mainCamera)
-        {
-
-            //Generate an array for the positions of the things we're rendering
-            //Bind the attrib arrays for each model
-            //Render the batch
-            //Disable the attrib arrays
-
-            //Bind the instance buffer (We only need to bind it once and
-            //reuse it)
-            //glBindBuffer(GL_ARRAY_BUFFER, instancePositionBuffer);
-            //Buffer orphaning
-            //glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-
-            //Loop through each key of the dictionary
-            //TODO: Potential concurrent modification exception
-            foreach (RenderBatchGroup cacheKey in renderCache.Keys)
-            {
-
-                //================
-                //SHARED BETWEEN BATCHES
-                //================
-
-                //Get a list of all things to render with this model
-                RenderBatchSet renderBatchSet = renderCache[cacheKey];
-                //Bind the vertex buffer object and the vertex array object
-                BindAttribArray(0, cacheKey.Model.VertexBufferObject, 3);
-                BindAttribArray(1, cacheKey.Model.UvBuffer, 2);
-
-                //Enable the 2nd vertex attrib array
-                BindAttribArray(2, instancePositionBuffer, 3);
-                //Enable the 3rd vertex attrib array
-                BindAttribArray(3, instanceTexDataBuffer, 4);
-                //Enable the 4th vertex attrib array
-                BindAttribArray(4, instanceScaleDataBuffer, 2);
-
-                //Set the vertex attrib divisors
-                //Always reuse the provided vertices, so don't increment
-                glVertexAttribDivisor(0, 0);
-                //Reuse the UVs for each instance
-                glVertexAttribDivisor(1, 0);
-                //1 position per instancei
-                glVertexAttribDivisor(2, 1);
-                //1 position per instance
-                glVertexAttribDivisor(3, 1);
-                //1 scale per instance
-                glVertexAttribDivisor(4, 1);
-
-                //Load in the textures
-                glBindTexture(GL_TEXTURE0, cacheKey.TextureUint);
-                glUniform1i(textureSamplerUniformLocation, 0);
-                glUniform1f(spriteWidthUniformLocation, renderBatchSet.textureData.FileWidth);
-                glUniform1f(spriteHeightUniformLocation, renderBatchSet.textureData.FileHeight);
-
-                //================
-                // Process each batch
-                //================
-
-                for (int i = renderBatchSet.renderBatches.Count - 1; i >= 0; i--)
-                {
-
-                    //Get the batch we are rendering
-                    RenderBatch batch = renderBatchSet.renderBatches[i];
-
-                    //Get the count of elements in this batch
-                    //If its the end batch, its the amount of render elements mod the batch size,
-                    //if its not the end batch then its the batch size (Non-last batches are full)
-                    int count = i == renderBatchSet.renderBatches.Count - 1 ? renderBatchSet.renderElements % RenderBatch.MAX_BATCH_SIZE : RenderBatch.MAX_BATCH_SIZE;
-
-                    //Now that we have the instance positions in an array, we
-                    //can send it to openGL and render.
-                    fixed (float* instancePositionArrayPointer = &batch.batchPositionArray[0])
-                    {
-                        glBindBuffer(GL_ARRAY_BUFFER, instancePositionBuffer);
-                        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-                        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(float) * 3 * count, instancePositionArrayPointer);
-                    }
-
-                    //Do the same for texture data
-                    fixed (float* instanceTexDataArrayPointer = &batch.batchSpriteData[0])
-                    {
-                        glBindBuffer(GL_ARRAY_BUFFER, instanceTexDataBuffer);
-                        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 4 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-                        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(float) * 4 * count, instanceTexDataArrayPointer);
-                    }
-
-                    //Finally, do the same for scaling data
-                    fixed (float* instanceScaleArrayPointer = &batch.batchSizeArray[0])
-                    {
-                        glBindBuffer(GL_ARRAY_BUFFER, instanceScaleDataBuffer);
-                        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 2 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
-                        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(float) * 2 * count, instanceScaleArrayPointer);
-                    }
-
-                    //Perform batch rendering
-                    //6 vertices so count of 6.
-                    glDrawArraysInstanced(GL_TRIANGLES, 0, cacheKey.Model.VerticesLength, count);
-
-                }
-
-                //Disable the vertex arrays
-                glDisableVertexAttribArray(0);
-                glDisableVertexAttribArray(1);
-                glDisableVertexAttribArray(2);
-                glDisableVertexAttribArray(3);
-                glDisableVertexAttribArray(4);
-            }
-
+            return null;
         }
 
         public override void EndRender()
-        { }
+        {
+            throw new NotImplementedException();
+        }
 
+        protected override uint GetUnmanagedBufferLocation(uint target, RenderBatchGroup targetBatch)
+        {
+            switch (target)
+            {
+                case 0:
+                    return targetBatch.Model.VertexBufferObject;
+                case 1:
+                    return targetBatch.Model.UvBuffer;
+            }
+            return 0;
+        }
     }
 }

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IBackgroundRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IBackgroundRenderable.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GJ2022.Rendering.RenderSystems.Interfaces
+{
+    interface IBackgroundRenderable : IInstanceRenderable<IBackgroundRenderable, BackgroundRenderSystem>
+    {
+
+
+
+    }
+}

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IInstanceRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IInstanceRenderable.cs
@@ -7,9 +7,8 @@ namespace GJ2022.Rendering.RenderSystems.Interfaces
         where TargetInterface : IInternalRenderable
         where TargetRenderSystem : RenderSystem<TargetInterface, TargetRenderSystem>
     {
-
+        //wrapper I guess
         RenderSystem<TargetInterface, TargetRenderSystem> RenderSystem { get; }
-
     }
 
     //NOTE:
@@ -20,6 +19,7 @@ namespace GJ2022.Rendering.RenderSystems.Interfaces
     //This prevents us dealing with a mess of generic classes self looping.
     public interface IInternalRenderable
     {
+
         //Store the renderable batch index somewhere, so it can be fetched later
         void SetRenderableBatchIndex(object associatedSet, int index);
 

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IInstanceRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IInstanceRenderable.cs
@@ -7,8 +7,9 @@ namespace GJ2022.Rendering.RenderSystems.Interfaces
         where TargetInterface : IInternalRenderable
         where TargetRenderSystem : RenderSystem<TargetInterface, TargetRenderSystem>
     {
-        //wrapper I guess
+
         RenderSystem<TargetInterface, TargetRenderSystem> RenderSystem { get; }
+
     }
 
     //NOTE:

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IInstanceRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IInstanceRenderable.cs
@@ -1,17 +1,34 @@
-﻿using GJ2022.Utility.MathConstructs;
+﻿using GJ2022.Rendering.Textures;
+using GJ2022.Utility.MathConstructs;
 
 namespace GJ2022.Rendering.RenderSystems.Interfaces
 {
-    public interface IInstanceRenderable
+    public interface IInstanceRenderable<TargetInterface, TargetRenderSystem> : IInternalRenderable
+        where TargetInterface : IInternalRenderable
+        where TargetRenderSystem : RenderSystem<TargetInterface, TargetRenderSystem>
     {
 
-        void SetRenderableBatchIndex(RenderBatchSet associatedSet, int index);
-
-        int GetRenderableBatchIndex(RenderBatchSet associatedSet);
-
-        //Required getters
-        Vector GetInstancePosition();
-        Vector GetInstanceScale();
+        RenderSystem<TargetInterface, TargetRenderSystem> RenderSystem { get; }
 
     }
+
+    //NOTE:
+    //I spent a really long time messing about with generic classes trying
+    //to get this working, but the problem I have created is impossible to solve.
+    //Since we don't actually care about what the associatedSet type is and only
+    //use it as a key, just pass it as an object so it can be whatever we want.
+    //This prevents us dealing with a mess of generic classes self looping.
+    public interface IInternalRenderable
+    {
+        //Store the renderable batch index somewhere, so it can be fetched later
+        void SetRenderableBatchIndex(object associatedSet, int index);
+
+        //Fetch the renderable batch index
+        int GetRenderableBatchIndex(object associatedSet);
+
+        //Get the attached renderable texture data
+        RendererTextureData GetRendererTextureData();
+
+    }
+
 }

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IStandardRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IStandardRenderable.cs
@@ -1,4 +1,5 @@
 ﻿using GJ2022.Rendering.Models;
+using GJ2022.Utility.MathConstructs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,12 +8,14 @@ using System.Threading.Tasks;
 
 namespace GJ2022.Rendering.RenderSystems.Interfaces
 {
-    interface IStandardRenderable : IInstanceRenderable<IStandardRenderable, InstanceRenderSystem>
+    public interface IStandardRenderable : IInstanceRenderable<IStandardRenderable, InstanceRenderSystem>
     {
 
         Model GetModel();
 
         uint GetTextureUint();
+
+        Vector GetPosition();
 
     }
 }

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IStandardRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IStandardRenderable.cs
@@ -1,0 +1,18 @@
+﻿using GJ2022.Rendering.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GJ2022.Rendering.RenderSystems.Interfaces
+{
+    interface IStandardRenderable : IInstanceRenderable<IStandardRenderable, InstanceRenderSystem>
+    {
+
+        Model GetModel();
+
+        uint GetTextureUint();
+
+    }
+}

--- a/GJ2022/Rendering/RenderSystems/LineRenderer/LineRenderer.cs
+++ b/GJ2022/Rendering/RenderSystems/LineRenderer/LineRenderer.cs
@@ -10,7 +10,7 @@ namespace GJ2022.Rendering.RenderSystems.LineRenderer
 {
     //TODO:
     //Currently this is just a full renderer replacement
-    class LineRenderer : RenderSystem<IInstanceRenderable>
+    class LineRenderer : RenderSystem<IStandardRenderable, LineRenderer>
     {
 
         public static LineRenderer Singleton;
@@ -19,6 +19,12 @@ namespace GJ2022.Rendering.RenderSystems.LineRenderer
         public List<Line> rendering { get; } = new List<Line>();
 
         protected override string SystemShaderName => "simple";
+
+        protected override int BufferCount => 0;
+
+        protected override int[] BufferWidths => throw new NotImplementedException();
+
+        protected override uint[] BufferDataPointsPerInstance => throw new NotImplementedException();
 
         //Location of uniform variables
         private int objectMatrixUniformLocation;
@@ -33,7 +39,7 @@ namespace GJ2022.Rendering.RenderSystems.LineRenderer
 
         public LineRenderer()
         {
-            Singleton = this;
+            SetSingleton();
         }
 
         /// <summary>
@@ -184,10 +190,15 @@ namespace GJ2022.Rendering.RenderSystems.LineRenderer
 
         protected override void SetSingleton()
         {
+            Singleton = this;
+        }
+
+        protected override RenderBatchGroup GetBatchGroup(IStandardRenderable renderable)
+        {
             throw new NotImplementedException();
         }
 
-        public override float[] GetBufferData(IInstanceRenderable renderableInterface)
+        public override float[] GetBufferData(IStandardRenderable targetItem, int bufferIndex)
         {
             throw new NotImplementedException();
         }

--- a/GJ2022/Rendering/RenderSystems/LineRenderer/LineRenderer.cs
+++ b/GJ2022/Rendering/RenderSystems/LineRenderer/LineRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GJ2022.Rendering.RenderSystems.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,7 +8,9 @@ using static OpenGL.Gl;
 
 namespace GJ2022.Rendering.RenderSystems.LineRenderer
 {
-    class LineRenderer : RenderSystem
+    //TODO:
+    //Currently this is just a full renderer replacement
+    class LineRenderer : RenderSystem<IInstanceRenderable>
     {
 
         public static LineRenderer Singleton;
@@ -179,5 +182,14 @@ namespace GJ2022.Rendering.RenderSystems.LineRenderer
 
         }
 
+        protected override void SetSingleton()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override float[] GetBufferData(IInstanceRenderable renderableInterface)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/GJ2022/Rendering/RenderSystems/OutlineQuadRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/OutlineQuadRenderSystem.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace GJ2022.Rendering.RenderSystems
 {
+    //TODO
     public class OutlineQuadRenderSystem : InstanceRenderSystem
     {
 

--- a/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatch.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatch.cs
@@ -42,10 +42,10 @@ namespace GJ2022.Rendering.RenderSystems
         /// </summary>
         public void UpdateInstance(int index)
         {
+            RenderInterface target = instanceRenderables[index];
             for (int i = 0; i < bufferArrays.Length; i++)
             {
-                RenderInterface target = instanceRenderables[i];
-                float[] bufferData = target.RenderSystem.GetBufferData(target, i);
+                float[] bufferData = (target as IInstanceRenderable<RenderInterface, TargetRenderSystem>).RenderSystem.GetBufferData(target, i);
                 UpdateBuffer(i, index, bufferData);
             }
         }

--- a/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatch.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatch.cs
@@ -45,9 +45,7 @@ namespace GJ2022.Rendering.RenderSystems
             for (int i = 0; i < bufferArrays.Length; i++)
             {
                 RenderInterface target = instanceRenderables[i];
-                TargetRenderSystem targetSystem = target.TargetRenderSystem;
-                float[] bufferData = target.
-                float[] bufferData = instanceRenderables[index].GetBufferData(i);
+                float[] bufferData = target.RenderSystem.GetBufferData(target, i);
                 UpdateBuffer(i, index, bufferData);
             }
         }

--- a/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatch.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatch.cs
@@ -8,19 +8,78 @@ namespace GJ2022.Rendering.RenderSystems
     ///  - Shared texture data
     ///  - Unique positions
     ///  - Unique texture data offsets
+    /// TODO: Should render systems handle the storing and fetching of data from its entities?
     /// </summary>
-    public class RenderBatch
+    public class RenderBatch<RenderInterface, TargetRenderSystem>
+        //Render interface: The interface being stored used by the render system
+        where RenderInterface : IInternalRenderable
+        //Target render system: The render system type we are targetting
+        where TargetRenderSystem : RenderSystem<RenderInterface, TargetRenderSystem>
     {
 
         public const int MAX_BATCH_SIZE = 25000;
 
-        public IInstanceRenderable[] instanceRenderables = new IInstanceRenderable[MAX_BATCH_SIZE];
+        public RenderInterface[] instanceRenderables = new RenderInterface[MAX_BATCH_SIZE];
 
-        public float[] batchPositionArray = new float[3 * MAX_BATCH_SIZE];
+        public float[][] bufferArrays;
 
-        public float[] batchSpriteData = new float[4 * MAX_BATCH_SIZE];
+        private int[] bufferWidths;
 
-        public float[] batchSizeArray = new float[2 * MAX_BATCH_SIZE];
+        public RenderBatch(int bufferCount, int[] bufferWidths)
+        {
+            this.bufferWidths = bufferWidths;
+            //Create the buffer arrays
+            bufferArrays = new float[bufferCount][];
+            //Fill the buffer arrays with proper widths
+            for (int i = 0; i < bufferCount; i++)
+            {
+                bufferArrays[i] = new float[bufferWidths[i] * MAX_BATCH_SIZE];
+            }
+        }
+
+        /// <summary>
+        /// Updates an instance stored in this batch at the specified index
+        /// </summary>
+        public void UpdateInstance(int index)
+        {
+            for (int i = 0; i < bufferArrays.Length; i++)
+            {
+                RenderInterface target = instanceRenderables[i];
+                TargetRenderSystem targetSystem = target.TargetRenderSystem;
+                float[] bufferData = target.
+                float[] bufferData = instanceRenderables[index].GetBufferData(i);
+                UpdateBuffer(i, index, bufferData);
+            }
+        }
+
+        /// <summary>
+        /// Update a buffer at the specified index with the specified data.
+        /// </summary>
+        public void UpdateBuffer(int buffer, int index, float[] data)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                bufferArrays[buffer][index * data.Length + i] = data[i];
+            }
+        }
+
+        /// <summary>
+        /// Copy this batch to another batch
+        /// </summary>
+        public void CopyTo(RenderBatch<RenderInterface, TargetRenderSystem> target, int sourceIndex, int targetIndex)
+        {
+            //Go through each buffer we need to copy
+            for (int i = 0; i < bufferArrays.Length; i++)
+            {
+                //Get the width of this buffer
+                int bufferWidth = bufferWidths[i];
+                //Copy elements across
+                for (int j = 0; j < bufferWidth; j++)
+                {
+                    target.bufferArrays[i][targetIndex * bufferWidth + j] = bufferArrays[i][sourceIndex * bufferWidth + j];
+                }
+            }
+        }
 
     }
 }

--- a/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatchGroup.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatchGroup.cs
@@ -12,14 +12,11 @@ namespace GJ2022.Rendering.RenderSystems
     //The key of render batches
     public struct RenderBatchGroup
     {
-        public RenderBatchGroup(ShaderSet shaders, Model model, uint textureUint)
+        public RenderBatchGroup(Model model, uint textureUint)
         {
-            Shaders = shaders;
             Model = model;
             TextureUint = textureUint;
         }
-
-        public ShaderSet Shaders { get; }
 
         public Model Model { get; }
 

--- a/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatchSet.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderBatch/RenderBatchSet.cs
@@ -5,32 +5,44 @@ using System.Linq;
 
 namespace GJ2022.Rendering.RenderSystems
 {
-    public class RenderBatchSet
+    public class RenderBatchSet<RenderInterface, TargetRenderSystem>
+        //Render interface: The interface being stored used by the render system
+        where RenderInterface : IInternalRenderable
+        //Target render system: The render system type we are targetting
+        where TargetRenderSystem : RenderSystem<RenderInterface, TargetRenderSystem>
     {
 
-        public List<RenderBatch> renderBatches = new List<RenderBatch>();
+        public List<RenderBatch<RenderInterface, TargetRenderSystem>> renderBatches = new List<RenderBatch<RenderInterface, TargetRenderSystem>>();
 
         public int renderElements = 0;
 
         //The texture data of the batch set
         public RendererTextureData textureData;
 
-        public RenderBatchSet(RendererTextureData textureData)
+        //The buffer count of each render batch
+        private int bufferCount;
+
+        //The buffer widths for each render batch
+        private int[] bufferWidths;
+
+        public RenderBatchSet(RendererTextureData textureData, int bufferCount, int[] bufferWidths)
         {
             this.textureData = textureData;
+            this.bufferCount = bufferCount;
+            this.bufferWidths = bufferWidths;
         }
 
         /// <summary>
         /// Adding to batches is simple, since we just stick it on the end.
         /// </summary>
-        public void AddToBatch(IInstanceRenderable element, RendererTextureData textureData)
+        public void AddToBatch(RenderInterface element, RendererTextureData textureData)
         {
-            RenderBatch batchToAddTo;
-            int positionInBatch = renderElements % RenderBatch.MAX_BATCH_SIZE;
+            RenderBatch<RenderInterface, TargetRenderSystem> batchToAddTo;
+            int positionInBatch = renderElements % RenderBatch<RenderInterface, TargetRenderSystem>.MAX_BATCH_SIZE;
             //We need to add a new render batch
             if (positionInBatch == 0)
             {
-                batchToAddTo = new RenderBatch();
+                batchToAddTo = new RenderBatch<RenderInterface, TargetRenderSystem>(bufferCount, bufferWidths);
                 renderBatches.Add(batchToAddTo);
                 Log.WriteLine($"Created new rendering batch, there are now {renderBatches.Count} batches in this set.", LogType.DEBUG);
             }
@@ -41,42 +53,10 @@ namespace GJ2022.Rendering.RenderSystems
             //Add to the batch
             batchToAddTo.instanceRenderables[positionInBatch] = element;
             element.SetRenderableBatchIndex(this, renderElements);
-            //Cache all these values that are generally constant
-            UpdateRenderablePosition(element);
-            UpdateRenderableScales(element);
-            batchToAddTo.batchSpriteData[positionInBatch * 4] = textureData.IndexX;
-            batchToAddTo.batchSpriteData[positionInBatch * 4 + 1] = textureData.IndexY;
-            batchToAddTo.batchSpriteData[positionInBatch * 4 + 2] = textureData.Width;
-            batchToAddTo.batchSpriteData[positionInBatch * 4 + 3] = textureData.Height;
+            //Cache the buffer values of the provided instance renderable
+            batchToAddTo.UpdateInstance(positionInBatch);
+            //Another render element has been added
             renderElements++;
-        }
-
-        /// <summary>
-        /// Updates the cache with the new position of the element.
-        /// This must be called when a renderable element moves in the game world
-        /// so the renderer world can update it as being moved.
-        /// Renderer actual positions and theoretical positions are not directly linked
-        /// so communication is needed between theoretical and physical systems.
-        /// </summary>
-        public void UpdateRenderablePosition(IInstanceRenderable element)
-        {
-            int locatedIndex = element.GetRenderableBatchIndex(this) % RenderBatch.MAX_BATCH_SIZE;
-            RenderBatch batch = GetContainingBatch(element.GetRenderableBatchIndex(this));
-            batch.batchPositionArray[locatedIndex * 3] = element.GetInstancePosition()[0];
-            batch.batchPositionArray[locatedIndex * 3 + 1] = element.GetInstancePosition()[1];
-            batch.batchPositionArray[locatedIndex * 3 + 2] = element.GetInstancePosition()[2];
-        }
-
-        /// <summary>
-        /// Updates the cache with the new scale of the element.
-        /// This must be called every single time a renderable element has its scale changed.
-        /// </summary>
-        public void UpdateRenderableScales(IInstanceRenderable element)
-        {
-            int locatedIndex = element.GetRenderableBatchIndex(this) % RenderBatch.MAX_BATCH_SIZE;
-            RenderBatch batch = GetContainingBatch(element.GetRenderableBatchIndex(this));
-            batch.batchSizeArray[locatedIndex * 2] = element.GetInstanceScale()[0];
-            batch.batchSizeArray[locatedIndex * 2 + 1] = element.GetInstanceScale()[1];
         }
 
         /// <summary>
@@ -85,30 +65,20 @@ namespace GJ2022.Rendering.RenderSystems
         /// O(n) [We could do O(1) but it would need more memory]
         /// </summary>
         /// <param name="element"></param>
-        public void RemoveFromBatch(IInstanceRenderable element)
+        public void RemoveFromBatch(RenderInterface element)
         {
-            int locatedIndex = element.GetRenderableBatchIndex(this) % RenderBatch.MAX_BATCH_SIZE;
-            RenderBatch batch = GetContainingBatch(element.GetRenderableBatchIndex(this));
+            int locatedIndex = element.GetRenderableBatchIndex(this) % RenderBatch<RenderInterface, TargetRenderSystem>.MAX_BATCH_SIZE;
+            RenderBatch<RenderInterface, TargetRenderSystem> batch = GetContainingBatch(element.GetRenderableBatchIndex(this));
             //Remove element from that batch
-            int positionOfLast = (renderElements - 1) % RenderBatch.MAX_BATCH_SIZE;
+            int positionOfLast = (renderElements - 1) % RenderBatch<RenderInterface, TargetRenderSystem>.MAX_BATCH_SIZE;
             //Get the last renderable data element
-            RenderBatch lastBatch = renderBatches.Last();
+            RenderBatch<RenderInterface, TargetRenderSystem> lastBatch = renderBatches.Last();
             //Move the element from the last index into this old position
             //Tell the element that it was moved
             batch.instanceRenderables[locatedIndex] = lastBatch.instanceRenderables[positionOfLast];
             batch.instanceRenderables[locatedIndex].SetRenderableBatchIndex(this, element.GetRenderableBatchIndex(this));
-            //Copy the data from the last batch element into the removed batch element
-            batch.batchPositionArray[locatedIndex * 3] = lastBatch.batchPositionArray[positionOfLast * 3];
-            batch.batchPositionArray[locatedIndex * 3 + 1] = lastBatch.batchPositionArray[positionOfLast * 3 + 1];
-            batch.batchPositionArray[locatedIndex * 3 + 2] = lastBatch.batchPositionArray[positionOfLast * 3 + 2];
-            //Copy across texture data
-            batch.batchSpriteData[locatedIndex * 4] = lastBatch.batchSpriteData[positionOfLast * 4];
-            batch.batchSpriteData[locatedIndex * 4 + 1] = lastBatch.batchSpriteData[positionOfLast * 4 + 1];
-            batch.batchSpriteData[locatedIndex * 4 + 2] = lastBatch.batchSpriteData[positionOfLast * 4 + 2];
-            batch.batchSpriteData[locatedIndex * 4 + 3] = lastBatch.batchSpriteData[positionOfLast * 4 + 3];
-            //Copy across the scale data
-            batch.batchSizeArray[locatedIndex * 2] = lastBatch.batchSizeArray[positionOfLast * 2];
-            batch.batchSizeArray[locatedIndex * 2 + 1] = lastBatch.batchSizeArray[positionOfLast * 2 + 1];
+            //Copy data from the last batch element into the current one
+            lastBatch.CopyTo(batch, positionOfLast, locatedIndex);
             //Decrease the render elements amount
             renderElements--;
             //If the position of the last element was the first in the array, remove the batch
@@ -119,9 +89,9 @@ namespace GJ2022.Rendering.RenderSystems
             Log.WriteLine($"Removed element from batch, new batch size: {renderElements}, new batch count: {renderBatches.Count}", LogType.DEBUG);
         }
 
-        public RenderBatch GetContainingBatch(int index)
+        public RenderBatch<RenderInterface, TargetRenderSystem> GetContainingBatch(int index)
         {
-            int batchIndex = index / RenderBatch.MAX_BATCH_SIZE;
+            int batchIndex = index / RenderBatch<RenderInterface, TargetRenderSystem>.MAX_BATCH_SIZE;
             return renderBatches[batchIndex];
         }
 

--- a/GJ2022/Rendering/RenderSystems/RenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderSystem.cs
@@ -7,11 +7,19 @@ using static OpenGL.Gl;
 
 namespace GJ2022.Rendering.RenderSystems
 {
+
+    public abstract class RenderSystem
+    {
+        public abstract unsafe void BeginRender(Camera mainCamera);
+        public abstract unsafe void RenderModels(Camera mainCamera);
+        public abstract void EndRender();
+    }
+
     /// <summary>
     /// Render systems, handles rendering related stuff
     /// </summary>
     /// <typeparam name="RenderTargetInterface">The interface used by things rendered by this system</typeparam>
-    public abstract class RenderSystem<RenderTargetInterface, TargetRenderSystem>
+    public abstract class RenderSystem<RenderTargetInterface, TargetRenderSystem> : RenderSystem
         where RenderTargetInterface : IInternalRenderable
         where TargetRenderSystem : RenderSystem<RenderTargetInterface, TargetRenderSystem>
     {
@@ -130,7 +138,7 @@ namespace GJ2022.Rendering.RenderSystems
         /// </summary>
         public virtual unsafe float* GetBufferPointer(RenderBatch<RenderTargetInterface, TargetRenderSystem> targetBatch, int index)
         {
-            fixed (float* ptr = &targetBatch.bufferArrays[0][index - USER_BUFFER_OFFSET])
+            fixed (float* ptr = &targetBatch.bufferArrays[index][0])
                 return ptr;
         }
 
@@ -168,7 +176,7 @@ namespace GJ2022.Rendering.RenderSystems
         /// <summary>
         /// Prepare the system for rendering
         /// </summary>
-        public virtual unsafe void BeginRender(Camera mainCamera)
+        public override unsafe void BeginRender(Camera mainCamera)
         {
             //Attach the shader set
             glUseProgram(programUint);
@@ -205,7 +213,7 @@ namespace GJ2022.Rendering.RenderSystems
         /// Render the models provided.
         /// Requires the ModelData instance and a list of renderable objects associated with that
         /// </summary>
-        public virtual unsafe void RenderModels(Camera mainCamera)
+        public override unsafe void RenderModels(Camera mainCamera)
         {
             //Generate an array for the positions of the things we're rendering
             //Bind the attrib arrays for each model
@@ -294,11 +302,6 @@ namespace GJ2022.Rendering.RenderSystems
             glUniform1f(uniformVariableLocations["spriteWidth"], renderBatchSet.textureData.FileWidth);
             glUniform1f(uniformVariableLocations["spriteHeight"], renderBatchSet.textureData.FileHeight);
         }
-
-        /// <summary>
-        /// Cleanup anything we did in beginRender
-        /// </summary>
-        public abstract void EndRender();
 
         /// <summary>
         /// Binds the atrib array at index provided, with the buffer data provided.

--- a/GJ2022/Rendering/RenderSystems/RenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/RenderSystem.cs
@@ -7,13 +7,19 @@ using static OpenGL.Gl;
 
 namespace GJ2022.Rendering.RenderSystems
 {
-    public abstract class RenderSystem
+    /// <summary>
+    /// Render systems, handles rendering related stuff
+    /// </summary>
+    /// <typeparam name="RenderTargetInterface">The interface used by things rendered by this system</typeparam>
+    public abstract class RenderSystem<RenderTargetInterface, TargetRenderSystem>
+        where RenderTargetInterface : IInternalRenderable
+        where TargetRenderSystem : RenderSystem<RenderTargetInterface, TargetRenderSystem>
     {
 
         //The cache of things we are rendering
         //Key: ModelData (objects with the same modeldata should reference the same class)
         //Value: List of Renderables being rendered with that model data
-        protected virtual Dictionary<RenderBatchGroup, RenderBatchSet> renderCache { get; } = new Dictionary<RenderBatchGroup, RenderBatchSet>();
+        protected virtual Dictionary<RenderBatchGroup, RenderBatchSet<RenderTargetInterface, TargetRenderSystem>> renderCache { get; } = new Dictionary<RenderBatchGroup, RenderBatchSet<RenderTargetInterface, TargetRenderSystem>>();
 
         //Name of the system shader
         protected abstract string SystemShaderName { get; }
@@ -21,33 +27,273 @@ namespace GJ2022.Rendering.RenderSystems
         //Shaders used by the render system
         protected ShaderSet SystemShaders { get; }
 
+        //Program uint used by the rendering system
         protected uint programUint;
+
+        //The count of buffers this render system uses
+        protected abstract int BufferCount { get; }
+
+        //The array containing how wide each buffer is.
+        //Buffers must be between 1 and 4 wide.
+        protected abstract int[] BufferWidths { get; }
+
+        //The attrib divisor for each buffer.
+        //0 indicates that the buffer data is shared between all instances (models, textures)
+        //1 indicates that each instance gets its own set of data (positions, colours etc.)
+        protected abstract uint[] BufferDataPointsPerInstance { get; }
+
+        //The buffer locations
+        private uint[] bufferLocations;
+
+        //The names of the uniform variables used by this render system
+        protected string[] UniformVariableNames => new string[] {
+            "viewMatrix",
+            "projectionMatrix",
+            "textureSampler",
+            "spriteWidth",
+            "spriteHeight"
+        };
+
+        //The uniform variable locations
+        protected Dictionary<string, int> uniformVariableLocations = new Dictionary<string, int>();
 
         public RenderSystem()
         {
+            //Create the shader set
             SystemShaders = new ShaderSet(SystemShaderName);
 
+            //Set the singleton
+            SetSingleton();
+
+            //Create the program used by this renderer
             programUint = glCreateProgram();
             Log.WriteLine($"Created new program: ID {programUint}", LogType.DEBUG);
 
+            //Call initialization callback
             Initialize();
         }
 
         /// <summary>
-        /// Initialize the rendering system
+        /// Start rendering the provided renderable object
         /// </summary>
-        public abstract void Initialize();
+        public virtual void StartRendering(RenderTargetInterface renderable)
+        {
+            RenderBatchGroup renderCacheKey = GetBatchGroup(renderable);
+            if (renderCache.ContainsKey(renderCacheKey))
+            {
+                renderCache[renderCacheKey].AddToBatch(renderable, renderable.GetRendererTextureData());
+            }
+            else
+            {
+                RenderBatchSet<RenderTargetInterface, TargetRenderSystem> batchSet = new RenderBatchSet<RenderTargetInterface, TargetRenderSystem>(renderable.GetRendererTextureData(), BufferCount, BufferWidths);
+                batchSet.AddToBatch(renderable, renderable.GetRendererTextureData());
+                renderCache.Add(renderCacheKey, batchSet);
+            }
+        }
+
+        /// <summary>
+        /// Stop rendering the target instance
+        /// </summary>
+        public virtual void StopRendering(RenderTargetInterface renderable)
+        {
+            RenderBatchGroup renderCacheKey = GetBatchGroup(renderable);
+            if (!renderCache.ContainsKey(renderCacheKey))
+            {
+                Log.WriteLine($"Failed to locate key in render dict", LogType.WARNING);
+                return;
+            }
+            renderCache[renderCacheKey].RemoveFromBatch(renderable);
+            //If the list stored at the key position is now empty, remove it from the render batch cache.
+            if (renderCache[renderCacheKey].renderElements == 0)
+            {
+                renderCache.Remove(renderCacheKey);
+            }
+        }
+
+        /// <summary>
+        /// Generates the render batch group from a provided T class
+        /// </summary>
+        protected abstract RenderBatchGroup GetBatchGroup(RenderTargetInterface renderable);
+
+        /// <summary>
+        /// Set the singleton instance of the rendering system.
+        /// </summary>
+        protected abstract void SetSingleton();
+
+        /// <summary>
+        /// Returns the buffer data for a specified renderable.
+        /// </summary>
+        public abstract float[] GetBufferData(RenderTargetInterface renderableInterface);
+
+        /// <summary>
+        /// Initialize the rendering system.
+        /// Bind all required buffers
+        /// </summary>
+        public virtual unsafe void Initialize()
+        {
+
+            bufferLocations = new uint[BufferCount];
+
+            for (int i = 0; i < BufferCount; i++)
+            {
+                //Generate a buffer and store it in the appropriate location
+                bufferLocations[i] = glGenBuffer();
+                //Bind the buffer
+                glBindBuffer(GL_ARRAY_BUFFER, bufferLocations[i]);
+                //Reserve space in that buffer
+                glBufferData(GL_ARRAY_BUFFER, sizeof(float) * BufferWidths[i] * RenderBatch<RenderTargetInterface, TargetRenderSystem>.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
+            }
+
+            //Uniform variable collection
+            //Attach the shader set
+            glUseProgram(programUint);
+            //Attach the shader set so we can grab uniform locations
+            //Link program and use program are required here, not sure what they do exactly.
+            SystemShaders.AttachShaders(programUint);
+            glLinkProgram(programUint);
+            LoadUniformLocations();
+            //Detatch the shaders
+            SystemShaders.DetatchShaders(programUint);
+        }
 
         /// <summary>
         /// Prepare the system for rendering
         /// </summary>
-        public abstract void BeginRender(Camera mainCamera);
+        public virtual unsafe void BeginRender(Camera mainCamera)
+        {
+            //Attach the shader set
+            glUseProgram(programUint);
+
+            //Attach the shader set so we can grab uniform locations
+            //Link program and use program are required here, not sure what they do exactly.
+            SystemShaders.AttachShaders(programUint);
+            glLinkProgram(programUint);
+
+            //Load the camera's view matrix
+            //Put the matrix into that uniform variable
+            glUniformMatrix4fv(uniformVariableLocations["viewMatrix"], 1, false, mainCamera.ViewMatrix.GetPointer());
+
+            //Load the camera's projection matrix
+            //Put the matrix into that uniform variable
+            glUniformMatrix4fv(uniformVariableLocations["projectionMatrix"], 1, false, mainCamera.ProjectionMatrix.GetPointer());
+
+            //Detatch the shaders
+            SystemShaders.DetatchShaders(programUint);
+        }
+
+        private unsafe void LoadUniformLocations()
+        {
+            //Reset just in case
+            uniformVariableLocations.Clear();
+            //Load all uniform variable locations
+            foreach (string uniformVariableName in UniformVariableNames)
+            {
+                uniformVariableLocations.Add(uniformVariableName, glGetUniformLocation(programUint, uniformVariableName));
+            }
+        }
 
         /// <summary>
         /// Render the models provided.
         /// Requires the ModelData instance and a list of renderable objects associated with that
         /// </summary>
-        public abstract void RenderModels(Camera mainCamera);
+        public virtual void RenderModels(Camera mainCamera)
+        {
+            //Generate an array for the positions of the things we're rendering
+            //Bind the attrib arrays for each model
+            //Render the batch
+            //Disable the attrib arrays
+
+            //Bind the instance buffer (We only need to bind it once and
+            //reuse it)
+            //glBindBuffer(GL_ARRAY_BUFFER, instancePositionBuffer);
+            //Buffer orphaning
+            //glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
+
+            //Loop through each key of the dictionary
+            //TODO: Potential concurrent modification exception
+            foreach (RenderBatchGroup cacheKey in renderCache.Keys)
+            {
+
+                //================
+                //SHARED BETWEEN BATCHES
+                //================
+
+                //Get a list of all things to render with this model
+                RenderBatchSet<RenderTargetInterface, TargetRenderSystem> renderBatchSet = renderCache[cacheKey];
+
+                //Bind the buffers
+                for (uint i = 0; i < BufferCount; i++)
+                {
+                    BindAttribArray(i, bufferLocations[i], BufferWidths[i]);
+                    glVertexAttribDivisor(i, BufferDataPointsPerInstance[i]);
+                }
+
+                //Load in the textures
+                glBindTexture(GL_TEXTURE0, cacheKey.TextureUint);
+                BindUniformData(renderBatchSet);
+
+                //================
+                // Process each batch
+                //================
+
+                for (int i = renderBatchSet.renderBatches.Count - 1; i >= 0; i--)
+                {
+
+                    //Get the batch we are rendering
+                    RenderBatch<RenderTargetInterface, TargetRenderSystem> batch = renderBatchSet.renderBatches[i];
+
+                    //Get the count of elements in this batch
+                    //If its the end batch, its the amount of render elements mod the batch size,
+                    //if its not the end batch then its the batch size (Non-last batches are full)
+                    int count = i == renderBatchSet.renderBatches.Count - 1 ? renderBatchSet.renderElements % RenderBatch<RenderTargetInterface, TargetRenderSystem>.MAX_BATCH_SIZE : RenderBatch<RenderTargetInterface, TargetRenderSystem>.MAX_BATCH_SIZE;
+
+                    //Now that we have the instance positions in an array, we
+                    //can send it to openGL and render.
+                    fixed (float* instancePositionArrayPointer = &batch.batchPositionArray[0])
+                    {
+                        glBindBuffer(GL_ARRAY_BUFFER, instancePositionBuffer);
+                        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
+                        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(float) * 3 * count, instancePositionArrayPointer);
+                    }
+
+                    //Do the same for texture data
+                    fixed (float* instanceTexDataArrayPointer = &batch.batchSpriteData[0])
+                    {
+                        glBindBuffer(GL_ARRAY_BUFFER, instanceTexDataBuffer);
+                        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 4 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
+                        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(float) * 4 * count, instanceTexDataArrayPointer);
+                    }
+
+                    //Finally, do the same for scaling data
+                    fixed (float* instanceScaleArrayPointer = &batch.batchSizeArray[0])
+                    {
+                        glBindBuffer(GL_ARRAY_BUFFER, instanceScaleDataBuffer);
+                        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 2 * RenderBatch.MAX_BATCH_SIZE, NULL, GL_STREAM_DRAW);
+                        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(float) * 2 * count, instanceScaleArrayPointer);
+                    }
+
+                    //Perform batch rendering
+                    //6 vertices so count of 6.
+                    glDrawArraysInstanced(GL_TRIANGLES, 0, cacheKey.Model.VerticesLength, count);
+
+                }
+
+                //Disable the vertex arrays
+                glDisableVertexAttribArray(0);
+                glDisableVertexAttribArray(1);
+                glDisableVertexAttribArray(2);
+                glDisableVertexAttribArray(3);
+                glDisableVertexAttribArray(4);
+            }
+
+        }
+
+        protected virtual unsafe void BindUniformData(RenderBatchSet<RenderTargetInterface, TargetRenderSystem> renderBatchSet)
+        {
+            glUniform1i(uniformVariableLocations["textureSampler"], 0);
+            glUniform1f(uniformVariableLocations["spriteWidth"], renderBatchSet.textureData.FileWidth);
+            glUniform1f(uniformVariableLocations["spriteHeight"], renderBatchSet.textureData.FileHeight);
+        }
 
         /// <summary>
         /// Cleanup anything we did in beginRender

--- a/GJ2022/Rendering/Renderable.cs
+++ b/GJ2022/Rendering/Renderable.cs
@@ -18,7 +18,6 @@ namespace GJ2022.Rendering
         //We need to sort in terms of models for optimisations
         public virtual ModelData ModelData { get; set; } = BlockModelData.Singleton;
 
-
         //The position of the object in 3D space
         public Vector position = new Vector(3);
 
@@ -26,14 +25,6 @@ namespace GJ2022.Rendering
         {
             this.position = position;
         }
-
-        //Is this object being rendered?
-        public bool IsRendering { get; set; } = false;
-
-        /// <summary>
-        /// Get the renderable texture data that can be used by the renderer
-        /// </summary>
-        public abstract RendererTextureData GetRendererTexture();
 
     }
 }

--- a/GJ2022/Rendering/Shaders/backgroundShader.frag
+++ b/GJ2022/Rendering/Shaders/backgroundShader.frag
@@ -1,15 +1,8 @@
 ﻿#version 330 core
 
 in vec2 UV;
-in vec4 texData;
 
 out vec4 result;
-
-uniform float spriteWidth;
-uniform float spriteHeight;
-uniform sampler2D textureSampler;
-
-const float border = 0.001;
 
 const vec3 topLeftColour = vec3(66.0/255.0, 91.0/255.0, 135.0/255.0);
 const vec3 bottomRightColour = vec3(46.0/255.0, 48.0/255.0, 51/255.0);

--- a/GJ2022/Rendering/Shaders/backgroundShader.vert
+++ b/GJ2022/Rendering/Shaders/backgroundShader.vert
@@ -2,13 +2,9 @@
 //The vertex data relative to the model.
 layout (location = 0) in vec3 pos;
 layout (location = 1) in vec2 vertexUv;
-layout (location = 2) in vec3 instancePos;
-layout (location = 3) in vec4 textureData;
-layout (location = 3) in vec2 instanceScale;
 
 //UV data
 out vec2 UV;
-out vec4 texData;
 
 // The translation matrix (Model, View)
 //uniform mat4 objectMatrix;

--- a/GJ2022/Rendering/Shaders/backgroundShader.vert
+++ b/GJ2022/Rendering/Shaders/backgroundShader.vert
@@ -28,5 +28,4 @@ void main()
 	gl_Position.z = 1.0;
     //Output the vertex UV to the fragment shader
     UV = vertexUv;
-    texData = textureData;
 }

--- a/GJ2022/Rendering/Shaders/instanceShader.vert
+++ b/GJ2022/Rendering/Shaders/instanceShader.vert
@@ -4,7 +4,6 @@ layout (location = 0) in vec3 pos;
 layout (location = 1) in vec2 vertexUv;
 layout (location = 2) in vec3 instancePos;
 layout (location = 3) in vec4 textureData;
-layout (location = 3) in vec2 instanceScale;
 
 //UV data
 out vec2 UV;


### PR DESCRIPTION
Updates the rendering system to V4, the mind shattering version.
This uses some really weird stuff like CRTP.
:)

This solves:
 - Entities can only be called to render on the system they should be rendering on. You can not make a renderable object render on 2 different systems.
 - Rendering systems now perform rendering based on interface calls rather than the renderable class.
 - Render systems now handle their own uniform variables and buffers rather than all sharing the same data in the buffer, meaning almost every shader ignores a majority of the data sent to it in some way.

This will make it easier to make a rendering system that has colour stored in a buffer for example, which will be needed when making rooms and people.

I'm suprised this actually works to be honest.
The aim is to contain the confusion inside the renderer as much as possible, so getting things to render from the outside is easy.
Also should be super performant due to using instancing and no longer packing buffers full of useless data.

How to render stuff?

Make a render system and an interface for things that get loaded into the render system.
Render system is a subtype of RenderSystem with the generic types <RenderInterface, CreatedRenderSystem>
Example:
```
public interface IStandardRenderable : IInstanceRenderable<IStandardRenderable, InstanceRenderSystem>
public class InstanceRenderSystem : RenderSystem<IStandardRenderable, InstanceRenderSystem>
```
Then apply the interface you created to any object you wish to be renderable.
Then call rendersystem.singleton.startRendering(interface) to render it.