### PR TITLE
Async pathfinding

### DIFF
--- a/GJ2022/Entities/Pawns/Pawn.cs
+++ b/GJ2022/Entities/Pawns/Pawn.cs
@@ -154,6 +154,7 @@ namespace GJ2022.Entities.Pawns
                 //Null the item target
                 heldItem = itemTarget;
                 itemTarget = null;
+                followingPath = null;
                 //Path towards the work target
                 PathfindingSystem.Singleton.RequestPath(
                     new PathfindingRequest(
@@ -187,6 +188,7 @@ namespace GJ2022.Entities.Pawns
             }
             else if (Position.IgnoreZ() == workTarget.Position.IgnoreZ())
             {
+                followingPath = null;
                 //Put materials into the work target
                 if (heldItem != null)
                     workTarget.PutMaterials(heldItem);

--- a/GJ2022/Rendering/RenderSystems/LineRenderer/LineRenderer.cs
+++ b/GJ2022/Rendering/RenderSystems/LineRenderer/LineRenderer.cs
@@ -171,8 +171,11 @@ namespace GJ2022.Rendering.RenderSystems.LineRenderer
             //of debugging.
             //We should probably disable the line renderer
             //all together if in release build.
-            foreach (Line line in rendering)
+            for(int i = rendering.Count - 1; i >= 0; i--)
             {
+                //Thread safe fetching
+                Line line = rendering[i];
+
                 //Send in data to the uniform values
                 glUniformMatrix4fv(objectMatrixUniformLocation, 1, false, line.ObjectMatrix.GetPointer());
 

--- a/GJ2022/Subsystems/PathfindingSystem.cs
+++ b/GJ2022/Subsystems/PathfindingSystem.cs
@@ -3,6 +3,7 @@ using GJ2022.Pathfinding;
 using GJ2022.Utility.MathConstructs;
 using GLFW;
 using System;
+using System.Threading.Tasks;
 
 namespace GJ2022.Subsystems
 {
@@ -41,12 +42,11 @@ namespace GJ2022.Subsystems
         public override int sleepDelay => 20;
 
         //No processing, but fires
-        public override SubsystemFlags SubsystemFlags => SubsystemFlags.NO_PROCESSING;
+        public override SubsystemFlags SubsystemFlags => SubsystemFlags.NO_UPDATE;
 
         public override void Fire(Window window)
         {
-            //TODO
-            return;
+            throw new NotImplementedException("Pathfinding system does not fire.");
         }
 
         public override void InitSystem() { }
@@ -55,8 +55,7 @@ namespace GJ2022.Subsystems
 
         public void RequestPath(PathfindingRequest request)
         {
-            //TODO
-            ProcessPath(request);
+            new Task(() => ProcessPath(request)).Start();
         }
 
         /// <summary>


### PR DESCRIPTION
Pathfinding is now asyncronous and won't pause all entities while running.
The entity waiting for a path will just sit there until a path is found.

Works with this long setup, other pawns continue to move while their siblings locate paths.
![image](https://user-images.githubusercontent.com/26465327/150975350-5d609a2e-32fa-4aba-80da-6adb54c563ca.png)
