### PR TITLE
Overlapping areas no longer crash the game

### DIFF
--- a/GJ2022/Areas/Area.cs
+++ b/GJ2022/Areas/Area.cs
@@ -1,16 +1,26 @@
 ﻿using GJ2022.Entities;
+using GJ2022.Entities.ComponentInterfaces;
 using GJ2022.Game.GameWorld;
 using GJ2022.Utility.MathConstructs;
 
 namespace GJ2022.Areas
 {
-    public abstract class Area : Entity
+    public abstract class Area : Entity, IDestroyable
     {
 
         protected Area(Vector<float> position) : base(position, Layers.LAYER_AREA)
         {
+            World.GetArea((int)position[0], (int)position[1])?.Destroy();
             World.SetArea((int)position[0], (int)position[1], this);
         }
 
+        public bool Destroyed { get; private set; } = false;
+
+        public override bool Destroy()
+        {
+            Destroyed = true;
+            World.SetArea((int)Position[0], (int)Position[1], null);
+            return base.Destroy();
+        }
     }
 }

--- a/GJ2022/Areas/StockpileArea.cs
+++ b/GJ2022/Areas/StockpileArea.cs
@@ -41,6 +41,14 @@ namespace GJ2022.Areas
             StockpileManager.RemoveItem(item);
         }
 
+        public override bool Destroy()
+        {
+            foreach (Item item in World.GetItems((int)Position[0], (int)Position[1]))
+            {
+                UnregisterItem(item);
+            }
+            return base.Destroy();
+        }
     }
 
 }


### PR DESCRIPTION
Allows areas to overlap, old areas will be deleted. Fixes a crash bug as a result of an unhandled exception.