### PR TITLE
Overlays + Worn icons (+Dogs)

### DIFF
--- a/GJ2022.Tests/RendererTests/RenderBatchTests/TestRenderBatches.cs
+++ b/GJ2022.Tests/RendererTests/RenderBatchTests/TestRenderBatches.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.Models;
+﻿using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.Models;
 using GJ2022.Rendering.RenderSystems;
 using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.Textures;
@@ -25,6 +26,8 @@ namespace GJ2022.Tests.RendererTests.RenderBatchTests
         private int sample;
 
         public RenderSystem<IStandardRenderable, InstanceRenderSystem> RenderSystem => InstanceRenderSystem.Singleton;
+
+        public Directions Direction => Directions.NONE;
 
         public Vector<float> GetInstancePosition() { return new Vector<float>(0, 0, 0); }
 

--- a/GJ2022/Data/TextureData.json
+++ b/GJ2022/Data/TextureData.json
@@ -303,6 +303,141 @@
       "height": 32,
       "index_x": 16,
       "index_y": 2
+    },
+    {
+      "id": "human_head_male",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 17,
+      "index_y": 2,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_head_female",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 21,
+      "index_y": 2,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_body_male",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 25,
+      "index_y": 2,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_body_female",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 29,
+      "index_y": 2,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_rightarm",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 1,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_leftarm",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 5,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_righthand",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 10,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_lefthand",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 14,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_rightleg",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 18,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "human_leftleg",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 22,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "jetpack_back",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 26,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "spacesuit_body",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 30,
+      "index_y": 3,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "syndicate_hardsuit_body",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 2,
+      "index_y": 4,
+      "directional": "CARDINAL"
+    },
+    {
+      "id": "spacesuit",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 6,
+      "index_y": 4,
+      "directional": "NONE"
+    },
+    {
+      "id": "syndicate_hardsuit",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 7,
+      "index_y": 4,
+      "directional": "NONE"
     }
   ]
 }

--- a/GJ2022/Data/TextureData.json
+++ b/GJ2022/Data/TextureData.json
@@ -438,6 +438,15 @@
       "index_x": 7,
       "index_y": 4,
       "directional": "NONE"
+    },
+    {
+      "id": "dog",
+      "file": "ground.bmp",
+      "width": 32,
+      "height": 32,
+      "index_x": 8,
+      "index_y": 4,
+      "directional": "CARDINAL"
     }
   ]
 }

--- a/GJ2022/Entities/ComponentInterfaces/IEquippable.cs
+++ b/GJ2022/Entities/ComponentInterfaces/IEquippable.cs
@@ -17,6 +17,9 @@ namespace GJ2022.Entities.ComponentInterfaces
         //Hazards this item protects from when equipped
         PawnHazards ProtectedHazards { get; }
 
+        //The texture when equpped, appended with _slot
+        string equipTexture { get; }
+
         //When the item is equipped
         void OnEquip(Pawn pawn, InventorySlot slot);
 

--- a/GJ2022/Entities/Entity.cs
+++ b/GJ2022/Entities/Entity.cs
@@ -168,7 +168,7 @@ namespace GJ2022.Entities
             {
                 Vector<float> oldPosition = _position.Copy();
                 _position = value;
-                Renderable?.moveHandler?.Invoke(_position);
+                Renderable?.UpdatePosition(_position);
                 (this as IMoveBehaviour)?.OnMoved(oldPosition);
                 if((int)oldPosition[0] != (int)value[0] || (int)oldPosition[1] != (int)value[1])
                     SignalHandler.SendSignal(this, SignalHandler.Signal.SIGNAL_ENTITY_MOVED, (Vector<int>)oldPosition);

--- a/GJ2022/Entities/Entity.cs
+++ b/GJ2022/Entities/Entity.cs
@@ -1,4 +1,5 @@
 ﻿using GJ2022.Entities.ComponentInterfaces;
+using GJ2022.Game.GameWorld;
 using GJ2022.Managers;
 using GJ2022.Rendering.RenderSystems;
 using GJ2022.Rendering.RenderSystems.Renderables;
@@ -29,6 +30,18 @@ namespace GJ2022.Entities
 
         //Texture change handler
         public string Texture { set { Renderable?.textureChangeHandler?.Invoke(value); } }
+
+        //Direction
+        private Directions _direction;
+        public Directions Direction
+        {
+            get => _direction;
+            set
+            {
+                _direction = value;
+                Renderable.UpdateDirection(value);
+            }
+        }
 
         //Don't set this outside of thread safe claim manager
         private bool isClaimed = false;
@@ -167,6 +180,7 @@ namespace GJ2022.Entities
             set
             {
                 Vector<float> oldPosition = _position.Copy();
+                Vector<float> delta = value - oldPosition;
                 _position = value;
                 Renderable?.UpdatePosition(_position);
                 (this as IMoveBehaviour)?.OnMoved(oldPosition);
@@ -174,6 +188,16 @@ namespace GJ2022.Entities
                     SignalHandler.SendSignal(this, SignalHandler.Signal.SIGNAL_ENTITY_MOVED, (Vector<int>)oldPosition);
                 if (attachedTextObject != null)
                     attachedTextObject.Position = value + textObjectOffset;
+                //Change direction
+                if (delta[0] > -delta[1])
+                    if (delta[0] < delta[1])
+                        Direction = Directions.NORTH;
+                    else
+                        Direction = Directions.EAST;
+                else if (delta[0] < delta[1])
+                    Direction = Directions.WEST;
+                else
+                    Direction = Directions.SOUTH;
             }
         }
 

--- a/GJ2022/Entities/Items/Clothing/Back/Jetpack.cs
+++ b/GJ2022/Entities/Items/Clothing/Back/Jetpack.cs
@@ -29,6 +29,8 @@ namespace GJ2022.Entities.Items.Clothing.Back
 
         public PawnHazards ProtectedHazards => PawnHazards.HAZARD_GRAVITY;
 
+        public string equipTexture => "jetpack";
+
         protected override Renderable Renderable { get; set; } = new StandardRenderable("jetpack");
 
         public void OnEquip(Pawn pawn, InventorySlot slot)

--- a/GJ2022/Entities/Items/Clothing/Body/SpaceSuit.cs
+++ b/GJ2022/Entities/Items/Clothing/Body/SpaceSuit.cs
@@ -1,0 +1,40 @@
+﻿using GJ2022.Entities.ComponentInterfaces;
+using GJ2022.Entities.Pawns;
+using GJ2022.PawnBehaviours;
+using GJ2022.Rendering.RenderSystems.Renderables;
+using GJ2022.Utility.MathConstructs;
+
+namespace GJ2022.Entities.Items.Clothing.Body
+{
+    class SpaceSuit : Item, IEquippable
+    {
+
+        public SpaceSuit(Vector<float> position) : base(position)
+        {
+        }
+
+        public override string Name => "Space Suit";
+
+        public override string UiTexture => "spacesuit";
+
+        public InventorySlot Slots => InventorySlot.SLOT_BODY;
+
+        public PawnHazards ProtectedHazards => PawnHazards.HAZARD_LOW_PRESSURE;
+
+        public string equipTexture => "spacesuit";
+
+        protected override Renderable Renderable { get; set; } = new StandardRenderable("spacesuit");
+
+        public void OnEquip(Pawn pawn, InventorySlot slot)
+        {
+            Location = pawn;
+        }
+
+        public void OnUnequip(Pawn pawn, InventorySlot slot)
+        {
+            Location = null;
+            Position = pawn.Position;
+        }
+
+    }
+}

--- a/GJ2022/Entities/Items/Clothing/Body/SyndicateHardsuit.cs
+++ b/GJ2022/Entities/Items/Clothing/Body/SyndicateHardsuit.cs
@@ -1,0 +1,39 @@
+﻿using GJ2022.Entities.ComponentInterfaces;
+using GJ2022.Entities.Pawns;
+using GJ2022.PawnBehaviours;
+using GJ2022.Rendering.RenderSystems.Renderables;
+using GJ2022.Utility.MathConstructs;
+
+namespace GJ2022.Entities.Items.Clothing.Body
+{
+    class SyndicateHardsuit : Item, IEquippable
+    {
+
+        public SyndicateHardsuit(Vector<float> position) : base(position)
+        {
+        }
+
+        public override string Name => "Syndicate Hardsuit";
+
+        public override string UiTexture => "syndicate_hardsuit";
+
+        public InventorySlot Slots => InventorySlot.SLOT_BODY;
+
+        public PawnHazards ProtectedHazards => PawnHazards.HAZARD_LOW_PRESSURE;
+
+        public string equipTexture => "syndicate_hardsuit";
+
+        protected override Renderable Renderable { get; set; } = new StandardRenderable("syndicate_hardsuit");
+
+        public void OnEquip(Pawn pawn, InventorySlot slot)
+        {
+            Location = pawn;
+        }
+
+        public void OnUnequip(Pawn pawn, InventorySlot slot)
+        {
+            Location = null;
+            Position = pawn.Position;
+        }
+    }
+}

--- a/GJ2022/Entities/Items/Stacks/Ores/IronOre.cs
+++ b/GJ2022/Entities/Items/Stacks/Ores/IronOre.cs
@@ -13,9 +13,7 @@ namespace GJ2022.Entities.Items.Stacks.Ores
     public class IronOre : Stack
     {
         public IronOre(Vector<float> position, int maxStackSize = 50, int stackSize = 1) : base(position, maxStackSize, stackSize)
-        {
-            Renderable.AddOverlay("banana", new StandardRenderable("sparkle"), Layer + 1);
-        }
+        { }
 
         public override string Name => "Iron Ore";
 

--- a/GJ2022/Entities/Items/Stacks/Ores/IronOre.cs
+++ b/GJ2022/Entities/Items/Stacks/Ores/IronOre.cs
@@ -1,4 +1,5 @@
 ﻿using GJ2022.Entities.Pawns;
+using GJ2022.Game.GameWorld;
 using GJ2022.Rendering.RenderSystems.Renderables;
 using GJ2022.Utility.MathConstructs;
 using System;
@@ -13,6 +14,7 @@ namespace GJ2022.Entities.Items.Stacks.Ores
     {
         public IronOre(Vector<float> position, int maxStackSize = 50, int stackSize = 1) : base(position, maxStackSize, stackSize)
         {
+            Renderable.AddOverlay("banana", new StandardRenderable("sparkle"), Layer + 1);
         }
 
         public override string Name => "Iron Ore";

--- a/GJ2022/Entities/Pawns/Dog.cs
+++ b/GJ2022/Entities/Pawns/Dog.cs
@@ -1,0 +1,26 @@
+﻿using GJ2022.Entities.ComponentInterfaces;
+using GJ2022.Rendering.RenderSystems.Renderables;
+using GJ2022.Utility.MathConstructs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GJ2022.Entities.Pawns
+{
+    public class Dog : Pawn
+    {
+
+        public Dog(Vector<float> position) : base(position)
+        {
+        }
+
+        protected override Renderable Renderable { get; set; } = new StandardRenderable("dog");
+
+        protected override void AddEquipOverlay(InventorySlot targetSlot, IEquippable item)
+        {
+            return;
+        }
+    }
+}

--- a/GJ2022/Entities/Pawns/Human.cs
+++ b/GJ2022/Entities/Pawns/Human.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GJ2022.Entities.ComponentInterfaces;
+using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.RenderSystems.Renderables;
+using GJ2022.Utility.MathConstructs;
+
+namespace GJ2022.Entities.Pawns
+{
+    public class Human : Pawn
+    {
+
+        public Human(Vector<float> position) : base(position)
+        {
+            Renderable.AddOverlay("head", new StandardRenderable("human_head_male"), Layers.LAYER_PAWN + 0.01f);
+            Renderable.AddOverlay("rarm", new StandardRenderable("human_rightarm"), Layers.LAYER_PAWN + 0.01f);
+            Renderable.AddOverlay("larm", new StandardRenderable("human_leftarm"), Layers.LAYER_PAWN + 0.01f);
+            Renderable.AddOverlay("rhand", new StandardRenderable("human_righthand"), Layers.LAYER_PAWN + 0.02f);
+            Renderable.AddOverlay("lhand", new StandardRenderable("human_lefthand"), Layers.LAYER_PAWN + 0.02f);
+            Renderable.AddOverlay("rleg", new StandardRenderable("human_rightleg"), Layers.LAYER_PAWN + 0.01f);
+            Renderable.AddOverlay("lleg", new StandardRenderable("human_leftleg"), Layers.LAYER_PAWN + 0.01f);
+            Renderable.UpdateDirection(Directions.EAST);
+        }
+
+        protected override Renderable Renderable { get; set; } = new StandardRenderable("human_body_male");
+
+        protected override void AddEquipOverlay(InventorySlot targetSlot, IEquippable item)
+        {
+            Renderable.AddOverlay($"wear_{InventoryHelper.GetSlotAppend(targetSlot)}", new StandardRenderable($"{item.equipTexture}_{InventoryHelper.GetSlotAppend(targetSlot)}"), Layers.LAYER_PAWN + 0.08f);
+        }
+    }
+}

--- a/GJ2022/Entities/Pawns/InventorySlot.cs
+++ b/GJ2022/Entities/Pawns/InventorySlot.cs
@@ -13,4 +13,22 @@ namespace GJ2022.Entities.Pawns
         SLOT_BODY = 1 << 1,
         SLOT_HEAD = 1 << 2,
     }
+
+    public static class InventoryHelper
+    {
+        public static string GetSlotAppend(InventorySlot slot)
+        {
+            switch (slot)
+            {
+                case InventorySlot.SLOT_BACK:
+                    return "back";
+                case InventorySlot.SLOT_BODY:
+                    return "body";
+                case InventorySlot.SLOT_HEAD:
+                    return "head";
+            }
+            return null;
+        }
+    }
+
 }

--- a/GJ2022/Entities/Pawns/Pawn.cs
+++ b/GJ2022/Entities/Pawns/Pawn.cs
@@ -71,7 +71,6 @@ namespace GJ2022.Entities.Pawns
         public Pawn(Vector<float> position) : base(position, Layers.LAYER_PAWN)
         {
             PawnControllerSystem.Singleton.StartProcessing(this);
-            attachedTextObject = new TextObject("pawn", Colour.White, position, TextObject.PositionModes.WORLD_POSITION, 0.8f);
             MouseCollisionSubsystem.Singleton.StartTracking(this);
         }
 
@@ -87,9 +86,12 @@ namespace GJ2022.Entities.Pawns
                 EquippedItems.Add(targetSlot, item);
                 item.OnEquip(this, targetSlot);
                 RecalculateHazardProtection();
+                AddEquipOverlay(targetSlot, item);
                 return true;
             });
         }
+
+        protected virtual void AddEquipOverlay(InventorySlot targetSlot, IEquippable item) { }
 
         /// <summary>
         /// Recalculate what hazards we are protected from
@@ -143,20 +145,6 @@ namespace GJ2022.Entities.Pawns
                 helpfulLine = Line.StartDrawingLine(Position.SetZ(10), endPos.SetZ(10));
             helpfulLine.Start = Position.SetZ(10);
             helpfulLine.End = endPos.SetZ(10);
-            //Debug contents
-            if (Contents != null)
-            {
-                string text = "";
-                foreach (Item item in Contents)
-                {
-                    text += item.Name + ", ";
-                }
-                attachedTextObject.Text = text;
-            }
-            else
-            {
-                attachedTextObject.Text = "n/a";
-            }
         }
 
         public List<Item> GetHeldItems()

--- a/GJ2022/Entities/Turfs/Standard/StandardRenderableTurf.cs
+++ b/GJ2022/Entities/Turfs/Standard/StandardRenderableTurf.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.Models;
+﻿using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.Models;
 using GJ2022.Rendering.RenderSystems;
 using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.Textures;
@@ -14,6 +15,8 @@ namespace GJ2022.Entities.Turfs.Standard
         protected abstract string Texture { get; }
 
         public RenderSystem<IStandardRenderable, InstanceRenderSystem> RenderSystem => InstanceRenderSystem.Singleton;
+
+        public Directions Direction => Directions.NONE;
 
         public StandardRenderableTurf(int x, int y) : base(x, y)
         {

--- a/GJ2022/Game/GameWorld/DirectionalModes.cs
+++ b/GJ2022/Game/GameWorld/DirectionalModes.cs
@@ -8,9 +8,58 @@ namespace GJ2022.Game.GameWorld
 {
     public enum DirectionalModes
     {
-        NONE,
-        CARDINAL,
-        CARDINAL_DIAGONAL,
-        FULL
+        NONE = 0,
+        CARDINAL = 1,
+        CARDINAL_DIAGONAL = 2,
+        FULL = 3
     }
+
+    public enum Directions
+    {
+        NONE = 0,
+        NORTH = 1,
+        EAST = 2,
+        SOUTH = 4,
+        WEST = 8,
+    }
+
+    public static class Direction
+    {
+
+        public static int GetDirectionalShift(DirectionalModes mode, Directions dir)
+        {
+            switch (mode)
+            {
+                case DirectionalModes.NONE:
+                    return 0;
+                case DirectionalModes.CARDINAL:
+                    switch (dir)
+                    {
+                        case Directions.SOUTH:
+                            return 0;
+                        case Directions.NORTH:
+                            return 1;
+                        case Directions.EAST:
+                            return 2;
+                        case Directions.WEST:
+                            return 3;
+                        default:
+                            return 0;
+                    }
+                //Todo: Figure out how byond handles these in texture files
+                case DirectionalModes.CARDINAL_DIAGONAL:
+                    switch (dir)
+                    {
+                        default:
+                            return 0;
+                    }
+                case DirectionalModes.FULL:
+                    return (int)dir;
+                default:
+                    return 0;
+            }
+        }
+
+    }
+
 }

--- a/GJ2022/PawnBehaviours/Behaviours/DogBehaviour.cs
+++ b/GJ2022/PawnBehaviours/Behaviours/DogBehaviour.cs
@@ -1,0 +1,24 @@
+﻿using GJ2022.Entities.Pawns;
+using GJ2022.PawnBehaviours.PawnActions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GJ2022.PawnBehaviours.Behaviours
+{
+    class DogBehaviour : PawnBehaviour
+    {
+
+        public DogBehaviour(Pawn owner) : base(owner)
+        { }
+
+        public override Dictionary<PawnAction, double> Actions { get; } = new Dictionary<PawnAction, double>()
+        {
+            { new HaulItems(), 0 },
+            { new ReturnToSpawn(), 0 }
+        };
+
+    }
+}

--- a/GJ2022/Program.cs
+++ b/GJ2022/Program.cs
@@ -92,7 +92,9 @@ namespace GJ2022
                 new CrewmemberBehaviour(p);
             }
 
-            new SyndicateHardsuit(new Vector<float>(4, 7));
+            Human syndicate = new Human(new Vector<float>(-15, 0));
+            new CrewmemberBehaviour(syndicate);
+            syndicate.TryEquipItem(InventorySlot.SLOT_BODY, new SyndicateHardsuit(new Vector<float>(4, 7)));
 
             for (int x = 4; x < 6; x++)
             {

--- a/GJ2022/Program.cs
+++ b/GJ2022/Program.cs
@@ -1,5 +1,6 @@
 ﻿using GJ2022.Entities.Debug;
 using GJ2022.Entities.Items.Clothing.Back;
+using GJ2022.Entities.Items.Clothing.Body;
 using GJ2022.Entities.Items.Stacks;
 using GJ2022.Entities.Items.Tools.Mining;
 using GJ2022.Entities.Pawns;
@@ -85,10 +86,13 @@ namespace GJ2022
             Pawn jetpackPawn = null;
             for (int i = 0; i < 4; i++)
             {
-                Pawn p = new Pawn(new Vector<float>(2.3f, 7.3f));
+                Human p = new Human(new Vector<float>(2.3f, 7.3f));
+                p.TryEquipItem(InventorySlot.SLOT_BODY, new SpaceSuit(new Vector<float>(0, 0)));
                 jetpackPawn = p;
                 new CrewmemberBehaviour(p);
             }
+
+            new SyndicateHardsuit(new Vector<float>(4, 7));
 
             for (int x = 4; x < 6; x++)
             {

--- a/GJ2022/Program.cs
+++ b/GJ2022/Program.cs
@@ -115,6 +115,12 @@ namespace GJ2022
             new Jetpack(new Vector<float>(9, 8));
             new Pickaxe(new Vector<float>(3, 2));
 
+            for (int i = 0; i < 100; i++)
+            {
+                Dog dog = new Dog(new Vector<float>(2, 2));
+                new DogBehaviour(dog);
+            }
+
             jetpackPawn.TryEquipItem(InventorySlot.SLOT_BACK, new Jetpack(new Vector<float>(9, 8)));
 
             Random r = new Random();

--- a/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.RenderSystems.Interfaces;
+﻿using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.Textures;
 using GJ2022.Utility.MathConstructs;
 using System;
@@ -50,9 +51,18 @@ namespace GJ2022.Rendering.RenderSystems
                     };
                 case 1:
                     RendererTextureData texData = targetItem.GetRendererTextureData();
+                    //Apply directional offset
+                    int indexX = texData.IndexX;
+                    int indexY = texData.IndexY;
+                    //Directional shift
+                    int directionalShift = Direction.GetDirectionalShift(targetItem.GetRendererTextureData().DirectionalMode, targetItem.Direction);
+                    indexX = (indexX + directionalShift) % (texData.FileWidth / texData.Width);
+                    Log.WriteLine($"{texData.FileWidth}, {texData.Width} : {(texData.FileWidth / texData.Width)}... {indexX}, {indexY}");
+                    //TODO: Don't assume that dirs can't go across 2 lines lol!
+                    indexY = indexY + ((texData.IndexX + directionalShift) >= (texData.FileWidth / texData.Width) ? 1 : 0);
                     return new float[] {
-                        texData.IndexX,
-                        texData.IndexY,
+                        indexX,
+                        indexY,
                         texData.Width,
                         texData.Height,
                     };

--- a/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
@@ -57,7 +57,6 @@ namespace GJ2022.Rendering.RenderSystems
                     //Directional shift
                     int directionalShift = Direction.GetDirectionalShift(targetItem.GetRendererTextureData().DirectionalMode, targetItem.Direction);
                     indexX = (indexX + directionalShift) % (texData.FileWidth / texData.Width);
-                    Log.WriteLine($"{texData.FileWidth}, {texData.Width} : {(texData.FileWidth / texData.Width)}... {indexX}, {indexY}");
                     //TODO: Don't assume that dirs can't go across 2 lines lol!
                     indexY = indexY + ((texData.IndexX + directionalShift) >= (texData.FileWidth / texData.Width) ? 1 : 0);
                     return new float[] {

--- a/GJ2022/Rendering/RenderSystems/Interfaces/IStandardRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Interfaces/IStandardRenderable.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.Models;
+﻿using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.Models;
 using GJ2022.Utility.MathConstructs;
 
 namespace GJ2022.Rendering.RenderSystems.Interfaces
@@ -11,6 +12,8 @@ namespace GJ2022.Rendering.RenderSystems.Interfaces
         uint GetTextureUint();
 
         Vector<float> GetPosition();
+
+        Directions Direction { get; }
 
     }
 }

--- a/GJ2022/Rendering/RenderSystems/Renderables/BackgroundRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/BackgroundRenderable.cs
@@ -35,6 +35,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = false;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
         public override void StartRendering()
@@ -44,6 +45,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = true;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void ContinueRendering()
@@ -52,6 +54,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void PauseRendering()
@@ -60,6 +63,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
     }

--- a/GJ2022/Rendering/RenderSystems/Renderables/BlueprintRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/BlueprintRenderable.cs
@@ -110,6 +110,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = false;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
         public override void StartRendering()
@@ -119,6 +120,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = true;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void ContinueRendering()
@@ -127,6 +129,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void PauseRendering()
@@ -135,6 +138,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
     }

--- a/GJ2022/Rendering/RenderSystems/Renderables/ButtonRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/ButtonRenderable.cs
@@ -31,7 +31,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             get { return _position; }
             set
             {
-                moveHandler?.Invoke(value);
+                UpdatePosition(value);
             }
         }
 
@@ -103,6 +103,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             isRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void StopRendering()
@@ -111,6 +112,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             isRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
         public override void PauseRendering()

--- a/GJ2022/Rendering/RenderSystems/Renderables/CircleRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/CircleRenderable.cs
@@ -91,6 +91,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = false;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
         public override void StartRendering()
@@ -100,6 +101,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = true;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void ContinueRendering()
@@ -108,6 +110,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void PauseRendering()
@@ -116,6 +119,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
     }
 }

--- a/GJ2022/Rendering/RenderSystems/Renderables/Renderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/Renderable.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.RenderSystems.Interfaces;
+﻿using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.Textures;
 using GJ2022.Utility.MathConstructs;
 using System.Collections.Generic;
@@ -29,6 +30,22 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         public abstract void StartRendering();
         public abstract void ContinueRendering();
         public abstract void PauseRendering();
+
+        public Directions Direction { get; private set; } = Directions.NONE;
+
+        public virtual void UpdateDirection(Directions direction)
+        {
+            Direction = direction;
+            if (Overlays == null)
+                return;
+            lock (Overlays)
+            {
+                foreach (Renderable overlay in Overlays.Values)
+                {
+                    overlay.UpdateDirection(direction);
+                }
+            }
+        }
 
         public void UpdatePosition(Vector<float> position)
         {

--- a/GJ2022/Rendering/RenderSystems/Renderables/Renderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/Renderable.cs
@@ -2,6 +2,7 @@
 using GJ2022.Rendering.Textures;
 using GJ2022.Utility.MathConstructs;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GJ2022.Rendering.RenderSystems.Renderables
 {
@@ -29,6 +30,13 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         public abstract void ContinueRendering();
         public abstract void PauseRendering();
 
+        public void UpdatePosition(Vector<float> position)
+        {
+            moveHandler?.Invoke(position);
+            _overlayPosition = position;
+            UpdateOvelayPosition(position);
+        }
+
         public void SetRenderableBatchIndex(object associatedSet, int index)
         {
             if (renderableBatchIndex.ContainsKey(associatedSet))
@@ -47,6 +55,84 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return renderableBatchIndex[associatedSet];
             else
                 return -1;
+        }
+
+        //Overlays
+        private Dictionary<string, Renderable> Overlays { get; set; } = null;
+
+        private Vector<float> _overlayPosition = new Vector<float>(0, 0);
+
+        private void UpdateOvelayPosition(Vector<float> position)
+        {
+            if (Overlays == null)
+                return;
+            lock (Overlays)
+            {
+                foreach (Renderable overlay in Overlays.Values)
+                {
+                    overlay.UpdatePosition(position);
+                }
+            }
+        }
+
+        public void StopRenderingOverlays()
+        {
+            if (Overlays == null)
+                return;
+            lock (Overlays)
+            {
+                foreach (Renderable overlay in Overlays.Values)
+                {
+                    overlay.StopRendering();
+                }
+            }
+        }
+
+        public void StartRenderingOverlays()
+        {
+            if (Overlays == null)
+                return;
+            lock (Overlays)
+            {
+                foreach (Renderable overlay in Overlays.Values)
+                {
+                    overlay.StartRendering();
+                }
+            }
+        }
+
+        public void AddOverlay(string id, Renderable overlay, float layer)
+        {
+            if (Overlays == null)
+                Overlays = new Dictionary<string, Renderable>();
+            overlay.UpdatePosition(_overlayPosition);
+            overlay.layerChangeHandler?.Invoke(layer);
+            lock (Overlays)
+            {
+                Overlays.Add(id, overlay);
+            }
+        }
+
+        public void ClearOverlays()
+        {
+            if (Overlays == null)
+                return;
+            lock (Overlays)
+            {
+                foreach (Renderable overlay in Overlays.Values)
+                {
+                    overlay.StopRendering();
+                }
+                Overlays.Clear();
+            }
+        }
+
+        public void RemoveOvelay(string id)
+        {
+            lock (Overlays)
+            {
+                Overlays.Remove(id);
+            }
         }
 
     }

--- a/GJ2022/Rendering/RenderSystems/Renderables/StandardRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/StandardRenderable.cs
@@ -1,4 +1,5 @@
-﻿using GJ2022.Rendering.Models;
+﻿using GJ2022.Game.GameWorld;
+using GJ2022.Rendering.Models;
 using GJ2022.Rendering.RenderSystems.Interfaces;
 using GJ2022.Rendering.Textures;
 using GJ2022.Utility.MathConstructs;
@@ -31,6 +32,13 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             _texture = texture;
             this.isTransparent = isTransparent;
             StartRendering();
+        }
+
+        public override void UpdateDirection(Directions direction)
+        {
+            base.UpdateDirection(direction);
+            if (renderableBatchIndex.Count > 0)
+                (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<IStandardRenderable, InstanceRenderSystem>)?.UpdateBatchData(this, 1);
         }
 
         //===================

--- a/GJ2022/Rendering/RenderSystems/Renderables/StandardRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/StandardRenderable.cs
@@ -113,6 +113,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = false;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
         public override void StartRendering()
@@ -122,6 +123,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             shouldContinueRendering = true;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void ContinueRendering()
@@ -130,6 +132,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void PauseRendering()
@@ -138,6 +141,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             IsRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
     }
 }

--- a/GJ2022/Rendering/RenderSystems/Renderables/UserInterfaceRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/UserInterfaceRenderable.cs
@@ -30,7 +30,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
             get { return _position; }
             set
             {
-                moveHandler?.Invoke(value);
+                UpdatePosition(value);
             }
         }
 
@@ -88,6 +88,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             isRendering = true;
             RenderSystem.StartRendering(this);
+            StartRenderingOverlays();
         }
 
         public override void StopRendering()
@@ -96,6 +97,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
                 return;
             isRendering = false;
             RenderSystem.StopRendering(this);
+            StopRenderingOverlays();
         }
 
         public override void PauseRendering()

--- a/GJ2022/Rendering/Shaders/InstanceShader/instanceShader.frag
+++ b/GJ2022/Rendering/Shaders/InstanceShader/instanceShader.frag
@@ -13,6 +13,7 @@ const float border = 0.001;
 
 void main()
 {
+
     vec2 transformedUV = (UV * (1-2*border)) + border;
 
     transformedUV = vec2(1.0 - transformedUV.y, 1.0 - transformedUV.x);

--- a/GJ2022/Rendering/Textures/RendererTextureData.cs
+++ b/GJ2022/Rendering/Textures/RendererTextureData.cs
@@ -1,4 +1,6 @@
-﻿namespace GJ2022.Rendering.Textures
+﻿using GJ2022.Game.GameWorld;
+
+namespace GJ2022.Rendering.Textures
 {
     /// <summary>
     /// Texture data used by the renderer
@@ -15,6 +17,7 @@
             IndexY = json.IndexY;
             FileWidth = texture.Width;
             FileHeight = texture.Height;
+            DirectionalMode = json.DirectionalModes;
         }
 
         public uint TextureUint { get; }
@@ -30,6 +33,8 @@
         public int IndexX { get; }
 
         public int IndexY { get; }
+
+        public DirectionalModes DirectionalMode { get; }
 
     }
 }

--- a/GJ2022/UserInterface/Components/UserInterfaceButton.cs
+++ b/GJ2022/UserInterface/Components/UserInterfaceButton.cs
@@ -45,7 +45,7 @@ namespace GJ2022.UserInterface.Components
             set
             {
                 _position = value;
-                Renderable?.moveHandler?.Invoke(value);
+                Renderable?.UpdatePosition(value);
                 TextObject.Position = value - CoordinateHelper.PixelsToScreen(new Vector<float>(90, 20));
             }
         }

--- a/GJ2022/UserInterface/Components/UserInterfaceImage.cs
+++ b/GJ2022/UserInterface/Components/UserInterfaceImage.cs
@@ -14,7 +14,7 @@ namespace GJ2022.UserInterface.Components
             get { return _position; }
             set {
                 _position = value;
-                Renderable?.moveHandler?.Invoke(value);
+                Renderable?.UpdatePosition(value);
             }
         }
 


### PR DESCRIPTION
Adds in the ability to apply ovelays to renderable objects.
Overlays can be any renderable object type and don't have to be the same type as the renderable they applied to (A sprite can be overlayed onto a circle).
Overlays also work as underlays.
TODO:
 - [ ] ~~Convert the layering system to be relative to the applied renderable.~~ nah
 - [x] Make pawns look swanky

![image](https://user-images.githubusercontent.com/26465327/151674527-17fc060c-ec87-42a5-b73c-f7488b7fb5d3.png)
![image](https://user-images.githubusercontent.com/26465327/151674614-77578236-7708-4e2d-82df-ce0de4274e4f.png)
![image](https://user-images.githubusercontent.com/26465327/151674999-30de2401-dcac-4766-a7d0-71577987137c.png)

