### PR TITLE
Sets pawn default bleedrate to 0, updates heart transfer rate

### DIFF
--- a/GJ2022/Entities/Pawns/Health/Bodies/Body.cs
+++ b/GJ2022/Entities/Pawns/Health/Bodies/Body.cs
@@ -96,7 +96,7 @@ namespace GJ2022.Entities.Pawns.Health.Bodies
         public abstract float BleedFixRate { get; }
 
         //Rate at which we are currently bleeding, in ml per second.
-        public float BleedRate { get; private set; } = 100;
+        public float BleedRate { get; private set; } = 0;
 
         /// <summary>
         /// Setup the body and its internal atmosphere

--- a/GJ2022/Entities/Pawns/Health/Bodyparts/Organs/BodyOrgans/Heart.cs
+++ b/GJ2022/Entities/Pawns/Health/Bodyparts/Organs/BodyOrgans/Heart.cs
@@ -22,7 +22,8 @@ namespace GJ2022.Entities.Pawns.Health.Bodyparts.Organs.BodyOrgans
             //this is just an arbitary number to stop pawns getting infinite oxygen and the lungs are always fine
             float maximumBodyOxygen = 0.05f;
             //Take oxygen from the internal atmosphere and put it into the body.
-            float transferedMoles = Math.Min(Math.Max(Math.Min(Body.internalAtmosphere.GetMoles(Oxygen.Singleton), maximumBodyOxygen) - Body.bloodstreamOxygenMoles, 0), TransferRate * deltaTime * Body.BloodEfficiency);
+            float transferEfficiency = (Body.internalAtmosphere.GetMoles(Oxygen.Singleton) / Body.internalAtmosphere.Moles);
+            float transferedMoles = Math.Min(Math.Max(Math.Min(Body.internalAtmosphere.GetMoles(Oxygen.Singleton) * transferEfficiency, maximumBodyOxygen) - Body.bloodstreamOxygenMoles, 0), TransferRate * deltaTime * Body.BloodEfficiency);
             Body.bloodstreamOxygenMoles += transferedMoles;
             Body.internalAtmosphere.SetMoles(Oxygen.Singleton, Body.internalAtmosphere.GetMoles(Oxygen.Singleton) - transferedMoles);
             //Put carbon dioxide from the body into the bodies internal atmosphere.


### PR DESCRIPTION
Pawns no longer spawn bleeding at a rate of 100ml/s.
The transfer rate of oxygen to the body is now proportional to the pressure in the lungs. (Low concentrations of oxygen in high pressure environments can survive but 100% oxygen at a low pressure will result in breathing troubles)