### PR TITLE
Updates vectors to use .X, .Y and .Z

### DIFF
--- a/GJ2022/Components/Atmospherics/Component_AtmosphericBlocker.cs
+++ b/GJ2022/Components/Atmospherics/Component_AtmosphericBlocker.cs
@@ -18,22 +18,22 @@ namespace GJ2022.Components.Atmospherics
         {
             Entity parent = Parent as Entity;
             blockingPosition = parent.Position;
-            World.AddAtmosphericBlocker(blockingPosition[0], blockingPosition[1]);
+            World.AddAtmosphericBlocker(blockingPosition.X, blockingPosition.Y);
             Parent.RegisterSignal(Signal.SIGNAL_ENTITY_MOVED, -1, ParentMoveReact);
         }
 
         public override void OnComponentRemove()
         {
-            World.RemoveAtmosphericBlock(blockingPosition[0], blockingPosition[1]);
+            World.RemoveAtmosphericBlock(blockingPosition.X, blockingPosition.Y);
             Parent.UnregisterSignal(Signal.SIGNAL_ENTITY_MOVED, ParentMoveReact);
         }
 
         private object ParentMoveReact(object source, params object[] parameters)
         {
-            World.RemoveAtmosphericBlock(blockingPosition[0], blockingPosition[1]);
+            World.RemoveAtmosphericBlock(blockingPosition.X, blockingPosition.Y);
             Entity parent = Parent as Entity;
             blockingPosition = parent.Position;
-            World.AddAtmosphericBlocker(blockingPosition[0], blockingPosition[1]);
+            World.AddAtmosphericBlocker(blockingPosition.X, blockingPosition.Y);
             return null;
         }
 

--- a/GJ2022/Components/Generic/Component_Tracked.cs
+++ b/GJ2022/Components/Generic/Component_Tracked.cs
@@ -23,8 +23,8 @@ namespace GJ2022.Components.Generic
             if (parent.Location != null)
                 return;
             //Start tracking
-            trackedX = (int)parent.Position[0];
-            trackedY = (int)parent.Position[1];
+            trackedX = (int)parent.Position.X;
+            trackedY = (int)parent.Position.Y;
             World.AddThing(Key, trackedX, trackedY, Parent);
             Parent.RegisterSignal(Signal.SIGNAL_ENTITY_MOVED, -1, OnParentMoved);
             Parent.RegisterSignal(Signal.SIGNAL_ENTITY_LOCATION, -1, OnLocationChanged);
@@ -53,8 +53,8 @@ namespace GJ2022.Components.Generic
             if (newLocation == null && oldLocation != null)
             {
                 Entity parent = Parent as Entity;
-                trackedX = (int)parent.Position[0];
-                trackedY = (int)parent.Position[1];
+                trackedX = (int)parent.Position.X;
+                trackedY = (int)parent.Position.Y;
                 World.AddThing(Key, trackedX, trackedY, Parent);
             }
             return null;
@@ -70,8 +70,8 @@ namespace GJ2022.Components.Generic
             //Remove the old track
             World.RemoveThing(Key, trackedX, trackedY, Parent);
             //Start tracking
-            trackedX = (int)parent.Position[0];
-            trackedY = (int)parent.Position[1];
+            trackedX = (int)parent.Position.X;
+            trackedY = (int)parent.Position.Y;
             World.AddThing(Key, trackedX, trackedY, Parent);
 
             return null;

--- a/GJ2022/Components/Items/Component_InternalEntity_Hardsuit.cs
+++ b/GJ2022/Components/Items/Component_InternalEntity_Hardsuit.cs
@@ -59,7 +59,7 @@ namespace GJ2022.Components.Items
 
         private bool ShouldDeployHelmet(Pawn pawn)
         {
-            Turf turf = World.GetTurf((int)pawn.Position[0], (int)pawn.Position[1]);
+            Turf turf = World.GetTurf((int)pawn.Position.X, (int)pawn.Position.Y);
             Atmosphere locatedAtmosphere = turf?.Atmosphere?.ContainedAtmosphere;
             if (locatedAtmosphere == null)
                 return true;

--- a/GJ2022/Entities/Areas/Area.cs
+++ b/GJ2022/Entities/Areas/Area.cs
@@ -16,15 +16,15 @@ namespace GJ2022.Entities.Areas
         public override bool Destroy()
         {
             Destroyed = true;
-            World.SetArea((int)Position[0], (int)Position[1], null);
+            World.SetArea((int)Position.X, (int)Position.Y, null);
             return base.Destroy();
         }
 
         public override void Initialize(Vector<float> initializePosition)
         {
             base.Initialize(initializePosition);
-            World.GetArea((int)initializePosition[0], (int)initializePosition[1])?.Destroy();
-            World.SetArea((int)initializePosition[0], (int)initializePosition[1], this);
+            World.GetArea((int)initializePosition.X, (int)initializePosition.Y)?.Destroy();
+            World.SetArea((int)initializePosition.X, (int)initializePosition.Y, this);
         }
     }
 }

--- a/GJ2022/Entities/Blueprints/TurfBlueprint.cs
+++ b/GJ2022/Entities/Blueprints/TurfBlueprint.cs
@@ -13,7 +13,7 @@ namespace GJ2022.Entities.Blueprints
         public override void Complete()
         {
             //Create an instance of the thingy
-            Activator.CreateInstance(BlueprintDetail.CreatedType, (int)Position[0], (int)Position[1]);
+            Activator.CreateInstance(BlueprintDetail.CreatedType, (int)Position.X, (int)Position.Y);
             //Destroy the blueprint
             Destroy();
         }

--- a/GJ2022/Entities/Debug/DebugCanister.cs
+++ b/GJ2022/Entities/Debug/DebugCanister.cs
@@ -14,7 +14,7 @@ namespace GJ2022.Entities.Debug
 
         public DebugCanister(Vector<float> position) : base(position, Layers.LAYER_STRUCTURE)
         {
-            Turf turf = World.GetTurf((int)position[0], (int)position[1]);
+            Turf turf = World.GetTurf((int)position.X, (int)position.Y);
             if (turf == null)
                 return;
             if (turf.Atmosphere == null)

--- a/GJ2022/Entities/Debug/DebugEntity.cs
+++ b/GJ2022/Entities/Debug/DebugEntity.cs
@@ -14,9 +14,9 @@ namespace GJ2022.Entities.Debug
     public class DebugEntity : Entity, IMouseEnter, IMouseExit, IDestroyable
     {
 
-        public float WorldX => Position[0] - 0.5f;
+        public float WorldX => Position.X - 0.5f;
 
-        public float WorldY => Position[1] - 0.5f;
+        public float WorldY => Position.Y - 0.5f;
 
         public float Width => 1.0f;
 

--- a/GJ2022/Entities/Entity.cs
+++ b/GJ2022/Entities/Entity.cs
@@ -197,7 +197,7 @@ namespace GJ2022.Entities
                 _position = value;
                 Renderable?.UpdatePosition(_position);
                 (this as IMoveBehaviour)?.OnMoved(oldPosition);
-                if ((int)oldPosition[0] != (int)value[0] || (int)oldPosition[1] != (int)value[1])
+                if ((int)oldPosition.X != (int)value[0] || (int)oldPosition.Y != (int)value[1])
                     SendSignal(Signal.SIGNAL_ENTITY_MOVED, (Vector<int>)oldPosition, value);
                 if (attachedTextObject != null)
                     attachedTextObject.Position = value + textObjectOffset;

--- a/GJ2022/Entities/Items/Item.cs
+++ b/GJ2022/Entities/Items/Item.cs
@@ -22,9 +22,9 @@ namespace GJ2022.Entities.Items
 
         public CursorSpace PositionSpace => CursorSpace.WORLD_SPACE;
 
-        public float WorldX => Position[0] - 0.5f;
+        public float WorldX => Position.X - 0.5f;
 
-        public float WorldY => Position[1] - 0.5f;
+        public float WorldY => Position.Y - 0.5f;
 
         public float Width => 1.0f;
 
@@ -44,8 +44,8 @@ namespace GJ2022.Entities.Items
         {
             base.Destroy();
             Destroyed = true;
-            World.RemoveItem((int)Position[0], (int)Position[1], this);
-            World.GetArea((int)Position[0], (int)Position[1])?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_REMOVED, this);
+            World.RemoveItem((int)Position.X, (int)Position.Y, this);
+            World.GetArea((int)Position.X, (int)Position.Y)?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_REMOVED, this);
             //Handle inventory removal
             if (Location is Pawn holder)
             {
@@ -61,13 +61,13 @@ namespace GJ2022.Entities.Items
         /// </summary>
         public void OnMoved(Vector<float> oldPosition)
         {
-            if ((int)oldPosition[0] == (int)Position[0] && (int)oldPosition[1] == (int)Position[1])
+            if ((int)oldPosition.X == (int)Position.X && (int)oldPosition.Y == (int)Position.Y)
                 return;
-            World.RemoveItem((int)oldPosition[0], (int)oldPosition[1], this);
-            World.AddItem((int)Position[0], (int)Position[1], this);
+            World.RemoveItem((int)oldPosition.X, (int)oldPosition.Y, this);
+            World.AddItem((int)Position.X, (int)Position.Y, this);
             //Calculate stockpile
-            World.GetArea((int)oldPosition[0], (int)oldPosition[1])?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_REMOVED, this);
-            World.GetArea((int)Position[0], (int)Position[1])?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_ADDED, this);
+            World.GetArea((int)oldPosition.X, (int)oldPosition.Y)?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_REMOVED, this);
+            World.GetArea((int)Position.X, (int)Position.Y)?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_ADDED, this);
         }
 
         public void OnMoved(Entity oldLocation)
@@ -80,8 +80,8 @@ namespace GJ2022.Entities.Items
                 return;
             }
             MouseCollisionSubsystem.Singleton.StopTracking(this);
-            World.RemoveItem((int)Position[0], (int)Position[1], this);
-            World.GetArea((int)Position[0], (int)Position[1])?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_REMOVED, this);
+            World.RemoveItem((int)Position.X, (int)Position.Y, this);
+            World.GetArea((int)Position.X, (int)Position.Y)?.SendSignal(Signal.SIGNAL_AREA_CONTENTS_REMOVED, this);
         }
 
         public void UpdateCount()

--- a/GJ2022/Entities/Markers/Marker.cs
+++ b/GJ2022/Entities/Markers/Marker.cs
@@ -17,19 +17,19 @@ namespace GJ2022.Entities.Markers
                 Destroy();
                 return;
             }
-            Marker marker = World.GetMarker((int)position[0], (int)position[1]);
+            Marker marker = World.GetMarker((int)position.X, (int)position.Y);
             if (marker != null)
             {
                 marker.Destroy();
                 return;
             }
-            World.SetMarker((int)position[0], (int)position[1], this);
+            World.SetMarker((int)position.X, (int)position.Y, this);
         }
 
         public override bool Destroy()
         {
             Destroyed = true;
-            World.SetMarker((int)Position[0], (int)Position[1], null);
+            World.SetMarker((int)Position.X, (int)Position.Y, null);
             return base.Destroy();
         }
 

--- a/GJ2022/Entities/Markers/MiningMarker.cs
+++ b/GJ2022/Entities/Markers/MiningMarker.cs
@@ -19,17 +19,17 @@ namespace GJ2022.Entities.Markers
             if (Destroyed)
                 return;
             //Register signal
-            World.GetTurf((int)Position[0], (int)Position[1]).RegisterSignal(Signal.SIGNAL_ENTITY_DESTROYED, 0, DestroyMarker);
+            World.GetTurf((int)Position.X, (int)Position.Y).RegisterSignal(Signal.SIGNAL_ENTITY_DESTROYED, 0, DestroyMarker);
         }
 
         public override bool IsValidPosition()
         {
-            return World.GetThings("Mine", (int)Position[0], (int)Position[1]).Count > 0;
+            return World.GetThings("Mine", (int)Position.X, (int)Position.Y).Count > 0;
         }
 
         public override bool Destroy()
         {
-            World.GetTurf((int)Position[0], (int)Position[1])?.UnregisterSignal(Signal.SIGNAL_ENTITY_DESTROYED, DestroyMarker);
+            World.GetTurf((int)Position.X, (int)Position.Y)?.UnregisterSignal(Signal.SIGNAL_ENTITY_DESTROYED, DestroyMarker);
             return base.Destroy();
         }
 
@@ -43,9 +43,9 @@ namespace GJ2022.Entities.Markers
 
         public void HandleAction(Pawn pawn)
         {
-            new AudioSource().PlaySound($"effects/picaxe{World.Random.Next(1, 4)}.wav", Position[0], Position[1]);
+            new AudioSource().PlaySound($"effects/picaxe{World.Random.Next(1, 4)}.wav", Position.X, Position.Y);
             //Perform mining
-            World.GetTurf((int)Position[0], (int)Position[1])?.SendSignal(Signal.SIGNAL_ENTITY_MINE, pawn);
+            World.GetTurf((int)Position.X, (int)Position.Y)?.SendSignal(Signal.SIGNAL_ENTITY_MINE, pawn);
             if(!Destroyed)
                 Destroy();
         }

--- a/GJ2022/Entities/Pawns/Health/Bodies/Body.cs
+++ b/GJ2022/Entities/Pawns/Health/Bodies/Body.cs
@@ -164,7 +164,7 @@ namespace GJ2022.Entities.Pawns.Health.Bodies
             //Process bleeding
             ProcessBleeding(deltaTime);
             //Process pressure damage (TODO: If not protected via pressure resistant clothing)
-            Turf location = World.GetTurf((int)Parent.Position[0], (int)Parent.Position[1]);
+            Turf location = World.GetTurf((int)Parent.Position.X, (int)Parent.Position.Y);
             float pressure = location?.Atmosphere?.ContainedAtmosphere.KiloPascalPressure ?? 0;
             for (int i = InsertedLimbs.Count - 1; i >= 0; i--)
             {

--- a/GJ2022/Entities/Pawns/Pawn.cs
+++ b/GJ2022/Entities/Pawns/Pawn.cs
@@ -28,9 +28,9 @@ namespace GJ2022.Entities.Pawns
 
         public CursorSpace PositionSpace => CursorSpace.WORLD_SPACE;
 
-        public float WorldX => Position[0] - 0.5f;
+        public float WorldX => Position.X - 0.5f;
 
-        public float WorldY => Position[1] - 0.5f;
+        public float WorldY => Position.Y - 0.5f;
 
         public float Width => 1.0f;
 
@@ -276,17 +276,17 @@ namespace GJ2022.Entities.Pawns
         /// </summary>
         public void OnMoved(Vector<float> oldPosition)
         {
-            if ((int)oldPosition[0] == (int)Position[0] && (int)oldPosition[1] == (int)Position[1])
+            if ((int)oldPosition.X == (int)Position.X && (int)oldPosition.Y == (int)Position.Y)
                 return;
-            World.RemovePawn((int)oldPosition[0], (int)oldPosition[1], this);
-            World.AddPawn((int)Position[0], (int)Position[1], this);
+            World.RemovePawn((int)oldPosition.X, (int)oldPosition.Y, this);
+            World.AddPawn((int)Position.X, (int)Position.Y, this);
         }
 
         public void OnMoved(Entity oldLocation)
         {
             if (oldLocation == Location)
                 return;
-            World.RemovePawn((int)Position[0], (int)Position[1], this);
+            World.RemovePawn((int)Position.X, (int)Position.Y, this);
         }
 
     }

--- a/GJ2022/Entities/Pawns/PawnBreathing.cs
+++ b/GJ2022/Entities/Pawns/PawnBreathing.cs
@@ -32,7 +32,7 @@ namespace GJ2022.Entities.Pawns
                 }
             }
             //Return atmosphere at the current location
-            return World.GetTurf((int)Position[0], (int)Position[1])?.Atmosphere?.ContainedAtmosphere;
+            return World.GetTurf((int)Position.X, (int)Position.Y)?.Atmosphere?.ContainedAtmosphere;
         }
 
         /// <summary>

--- a/GJ2022/Entities/Structures/Fire.cs
+++ b/GJ2022/Entities/Structures/Fire.cs
@@ -27,14 +27,14 @@ namespace GJ2022.Entities.Structures
         public override void Initialize(Vector<float> initializePosition)
         {
             FireProcessingSystem.Singleton.StartProcessing(this);
-            GlobalFires.Add((int)Position[0], (int)Position[1], this);
+            GlobalFires.Add((int)Position.X, (int)Position.Y, this);
             base.Initialize(initializePosition);
         }
 
         public Fire(Vector<float> position) : base(position, Layers.LAYER_FIRE)
         {
             FireProcessingSystem.Singleton.StartProcessing(this);
-            GlobalFires.Add((int)position[0], (int)position[1], this);
+            GlobalFires.Add((int)position.X, (int)position.Y, this);
         }
 
         public override Renderable Renderable { get; set; } = new StandardRenderable("fire", true);
@@ -42,14 +42,14 @@ namespace GJ2022.Entities.Structures
         public override bool Destroy()
         {
             FireProcessingSystem.Singleton.StopProcessing(this);
-            GlobalFires.Remove((int)Position[0], (int)Position[1]);
+            GlobalFires.Remove((int)Position.X, (int)Position.Y);
             return base.Destroy();
         }
 
         public void Process(float deltaTime)
         {
             //Get the current turf
-            Turf turf = World.GetTurf((int)Position[0], (int)Position[1]);
+            Turf turf = World.GetTurf((int)Position.X, (int)Position.Y);
             //Check turf atmos
             if (turf == null || turf.Atmosphere == null)
             {
@@ -84,8 +84,8 @@ namespace GJ2022.Entities.Structures
                 new Vector<int>(0, -1)
             };
             //Get position
-            int x = (int)Position[0];
-            int y = (int)Position[1];
+            int x = (int)Position.X;
+            int y = (int)Position.Y;
             //Check if we want to spread
             if (Random.NextDouble() > FIRE_SPREAD_CHANCE * molesOfOxygenLeft)
                 return;

--- a/GJ2022/Entities/Structures/Power/AreaPowerController.cs
+++ b/GJ2022/Entities/Structures/Power/AreaPowerController.cs
@@ -40,8 +40,8 @@ namespace GJ2022.Entities.Structures.Power
                     offset = new Vector<float>(0, -offsetAmount);
                     break;
             }
-            World.AddAreaPowerController((int)position[0], (int)position[1], this);
-            World.AddPowernetInteractor((int)position[0], (int)position[1], PowernetInteractor);
+            World.AddAreaPowerController((int)position.X, (int)position.Y, this);
+            World.AddPowernetInteractor((int)position.X, (int)position.Y, PowernetInteractor);
             Position += offset;
             //TODO: Move this to a definition file
             insertedCell = EntityCreator.CreateEntity<Entity>("Cell_Standard", position);
@@ -64,8 +64,8 @@ namespace GJ2022.Entities.Structures.Power
         public override bool Destroy()
         {
             Position -= offset;
-            World.RemoveAreaPowerController((int)Position[0], (int)Position[1], this);
-            World.RemovePowernetInteractor((int)Position[0], (int)Position[1], PowernetInteractor);
+            World.RemoveAreaPowerController((int)Position.X, (int)Position.Y, this);
+            World.RemovePowernetInteractor((int)Position.X, (int)Position.Y, PowernetInteractor);
             PowerProcessingSystem.Singleton.StopProcessing(this);
             return base.Destroy();
         }

--- a/GJ2022/Entities/Structures/Power/PacmanGenerator.cs
+++ b/GJ2022/Entities/Structures/Power/PacmanGenerator.cs
@@ -17,7 +17,7 @@ namespace GJ2022.Entities.Structures.Power
 
         public PacmanGenerator(Vector<float> position) : base(position, Layers.LAYER_STRUCTURE)
         {
-            World.AddPowernetInteractor((int)Position[0], (int)Position[1], PowernetInteractor);
+            World.AddPowernetInteractor((int)Position.X, (int)Position.Y, PowernetInteractor);
             PowerProcessingSystem.Singleton.StartProcessing(this);
         }
 
@@ -31,7 +31,7 @@ namespace GJ2022.Entities.Structures.Power
 
         public override bool Destroy()
         {
-            World.RemovePowernetInteractor((int)Position[0], (int)Position[1], PowernetInteractor);
+            World.RemovePowernetInteractor((int)Position.X, (int)Position.Y, PowernetInteractor);
             PowerProcessingSystem.Singleton.StopProcessing(this);
             return base.Destroy();
         }

--- a/GJ2022/Entities/Structures/Power/PowerConduit.cs
+++ b/GJ2022/Entities/Structures/Power/PowerConduit.cs
@@ -17,7 +17,7 @@ namespace GJ2022.Entities.Structures.Power
     {
         public PowerConduit(Vector<float> position) : base(position, Layers.LAYER_CONDUIT)
         {
-            if (LocateConduit((int)position[0], (int)position[1]) != null)
+            if (LocateConduit((int)position.X, (int)position.Y) != null)
             {
                 Destroy(false);
             }
@@ -26,7 +26,7 @@ namespace GJ2022.Entities.Structures.Power
                 textObjectOffset = new Vector<float>(0, -0.6f);
                 attachedTextObject = new TextObject($"{Powernet?.PowernetId}", Colour.White, Position + textObjectOffset, TextObject.PositionModes.WORLD_POSITION, 0.4f);
                 AddNode();
-                World.SetPowerCable((int)position[0], (int)position[1], this);
+                World.SetPowerCable((int)position.X, (int)position.Y, this);
             }
         }
 
@@ -61,7 +61,7 @@ namespace GJ2022.Entities.Structures.Power
             if (!base.Destroy())
                 return false;
             RemoveNode();
-            World.SetPowerCable((int)Position[0], (int)Position[1], null);
+            World.SetPowerCable((int)Position.X, (int)Position.Y, null);
             return true;
         }
 
@@ -174,8 +174,8 @@ namespace GJ2022.Entities.Structures.Power
 
         public void LocateAdjacentConduits()
         {
-            int x = (int)Position[0];
-            int y = (int)Position[1];
+            int x = (int)Position.X;
+            int y = (int)Position.Y;
             //Locate adjacent nodes
             northConduit = LocateConduit(x, y + 1);
             eastConduit = LocateConduit(x + 1, y);

--- a/GJ2022/Entities/Structures/Structure.cs
+++ b/GJ2022/Entities/Structures/Structure.cs
@@ -15,7 +15,7 @@ namespace GJ2022.Entities.Structures
 
         public override void Initialize(Vector<float> initializePosition)
         {
-            World.AddStructure((int)initializePosition[0], (int)initializePosition[1], this);
+            World.AddStructure((int)initializePosition.X, (int)initializePosition.Y, this);
             base.Initialize(initializePosition);
         }
 
@@ -23,7 +23,7 @@ namespace GJ2022.Entities.Structures
         public Structure(Vector<float> position, float layer) : base(position, layer)
         {
             //Add the structure to the world list
-            World.AddStructure((int)position[0], (int)position[1], this);
+            World.AddStructure((int)position.X, (int)position.Y, this);
         }
 
         public bool Destroyed { get; private set; } = false;
@@ -31,7 +31,7 @@ namespace GJ2022.Entities.Structures
         public override bool Destroy()
         {
             Destroyed = true;
-            World.RemoveStructure((int)Position[0], (int)Position[1], this);
+            World.RemoveStructure((int)Position.X, (int)Position.Y, this);
             return base.Destroy();
         }
     }

--- a/GJ2022/Entities/Turfs/Turf.cs
+++ b/GJ2022/Entities/Turfs/Turf.cs
@@ -41,8 +41,8 @@ namespace GJ2022.Entities.Turfs
 
         public override void Initialize(Vector<float> initializePosition)
         {
-            X = (int)initializePosition[0];
-            Y = (int)initializePosition[1];
+            X = (int)initializePosition.X;
+            Y = (int)initializePosition.Y;
             //Set the position to update the renderable
             Position = new Vector<float>(X, Y);
             //Destroy the old turf

--- a/GJ2022/Game/GameWorld/World.cs
+++ b/GJ2022/Game/GameWorld/World.cs
@@ -645,7 +645,7 @@ namespace GJ2022.Game.GameWorld
 
         public static bool IsSolid(Vector<int> position)
         {
-            return IsSolid(position[0], position[1]);
+            return IsSolid(position.X, position.Y);
         }
 
         /// <summary>
@@ -664,7 +664,7 @@ namespace GJ2022.Game.GameWorld
 
         public static bool HasGravity(Vector<int> position)
         {
-            return HasGravity(position[0], position[1]);
+            return HasGravity(position.X, position.Y);
         }
 
         public static bool HasGravity(int x, int y)

--- a/GJ2022/Game/Power/Powernet.cs
+++ b/GJ2022/Game/Power/Powernet.cs
@@ -77,7 +77,7 @@ namespace GJ2022.Game.Power
                 conduit.attachedTextObject.Text = $"{PowernetId}";
                 conduits.Add(conduit);
                 //Update attached powernets
-                foreach (PowernetInteractor interactor in World.GetPowernetInteractors((int)conduit.Position[0], (int)conduit.Position[1]))
+                foreach (PowernetInteractor interactor in World.GetPowernetInteractors((int)conduit.Position.X, (int)conduit.Position.Y))
                 {
                     interactor.AttachedPowernet = this;
                 }

--- a/GJ2022/Managers/Stockpile/StockpileManager.cs
+++ b/GJ2022/Managers/Stockpile/StockpileManager.cs
@@ -58,7 +58,7 @@ namespace GJ2022.Managers.Stockpile
         public static void AddStockpileArea(Vector<float> position)
         {
             //Add all items at this position to the stockpile
-            foreach (Item item in World.GetItems((int)position[0], (int)position[1]))
+            foreach (Item item in World.GetItems((int)position.X, (int)position.Y))
             {
                 AddItem(item);
             }
@@ -66,7 +66,7 @@ namespace GJ2022.Managers.Stockpile
 
         public static void RemoveStockpileArea(Vector<float> position)
         {
-            foreach (Item item in World.GetItems((int)position[0], (int)position[1]))
+            foreach (Item item in World.GetItems((int)position.X, (int)position.Y))
             {
                 RemoveItem(item);
             }

--- a/GJ2022/PawnBehaviours/PawnActions/HaulItems.cs
+++ b/GJ2022/PawnBehaviours/PawnActions/HaulItems.cs
@@ -46,21 +46,21 @@ namespace GJ2022.PawnBehaviours.PawnActions
         {
             if (parent.Owner.InCrit)
                 return false;
-            if (World.HasAreaInRange((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 40, (Area area) =>
+            if (World.HasAreaInRange((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 40, (Area area) =>
             {
                 if (unreachablePositions.Contains(area.Position))
                     return false;
-                if (World.GetThings("Stockpile", (int)area.Position[0], (int)area.Position[1]).Count > 0)
+                if (World.GetThings("Stockpile", (int)area.Position.X, (int)area.Position.Y).Count > 0)
                     return false;
                 return true;
             })
-                && World.HasItemsInRange((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 40, (List<Item> toCheck) =>
+                && World.HasItemsInRange((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 40, (List<Item> toCheck) =>
                 {
                     foreach (Item item in toCheck)
                     {
                         if (unreachablePositions.Contains(item.Position))
                             continue;
-                        if (World.GetThings("Stockpile", (int)item.Position[0], (int)item.Position[1]).Count > 0)
+                        if (World.GetThings("Stockpile", (int)item.Position.X, (int)item.Position.Y).Count > 0)
                             continue;
                         return true;
                     }
@@ -166,7 +166,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                 StoreHeldItems(parent);
             }
             //Check if the claimed area location is still empty
-            else if (World.GetItems((int)claimedArea.Position[0], (int)claimedArea.Position[1]).Count > 0)
+            else if (World.GetItems((int)claimedArea.Position.X, (int)claimedArea.Position.Y).Count > 0)
             {
                 //Redeliver items
                 StoreHeldItems(parent);
@@ -193,7 +193,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                 return;
             }
             //Attempt to locate items
-            List<Item> itemsToSearch = World.GetSprialItems((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 40);
+            List<Item> itemsToSearch = World.GetSprialItems((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 40);
             Item targetItem = null;
             if (forcedTarget == null)
             {
@@ -211,7 +211,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                         continue;
                     //Check if the item
                     //is in a stockpile, if it is, skip it
-                    if (World.GetThings("Stockpile", (int)item.Position[0], (int)item.Position[1]).Count > 0)
+                    if (World.GetThings("Stockpile", (int)item.Position.X, (int)item.Position.Y).Count > 0)
                         continue;
                     //Looks like the item is valid!
                     targetItem = item;
@@ -220,7 +220,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
             }
             else
             {
-                if (!forcedTarget.IsClaimed && forcedTarget.Location == null && !unreachablePositions.Contains(forcedTarget.Position) && World.GetThings("Stockpile", (int)forcedTarget.Position[0], (int)forcedTarget.Position[1]).Count == 0)
+                if (!forcedTarget.IsClaimed && forcedTarget.Location == null && !unreachablePositions.Contains(forcedTarget.Position) && World.GetThings("Stockpile", (int)forcedTarget.Position.X, (int)forcedTarget.Position.Y).Count == 0)
                     targetItem = forcedTarget;
             }
             //No item was located
@@ -257,7 +257,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
             }
             Area freeStockpileArea = null;
             //Extend range for forced haul
-            foreach (Area area in World.GetSpiralThings<Area>("Stockpile", (int)parent.Owner.Position[0], (int)parent.Owner.Position[1], forcedTarget == null ? 60 : 120))
+            foreach (Area area in World.GetSpiralThings<Area>("Stockpile", (int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, forcedTarget == null ? 60 : 120))
             {
                 //If the area is claimed, skip it
                 if (area.IsClaimed)
@@ -266,7 +266,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                 if (unreachablePositions.Contains(area.Position))
                     continue;
                 //If the area has items in it, skip it
-                if (World.GetItems((int)area.Position[0], (int)area.Position[1]).Count > 0)
+                if (World.GetItems((int)area.Position.X, (int)area.Position.Y).Count > 0)
                     continue;
                 //A good stockpile area
                 freeStockpileArea = area;

--- a/GJ2022/PawnBehaviours/PawnActions/MineAction.cs
+++ b/GJ2022/PawnBehaviours/PawnActions/MineAction.cs
@@ -31,7 +31,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
             if (parent.Owner.InCrit)
                 return false;
             //Quick check
-            return World.HasMarkerInRange((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 60, (Marker toCheck) =>
+            return World.HasMarkerInRange((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 60, (Marker toCheck) =>
             {
                 return !unreachableLocations.Contains(toCheck.Position);
             });
@@ -64,7 +64,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                 return;
             }
             //Go towards the blueprint
-            Vector<float>? targetPosition = World.GetFreeAdjacentLocation((int)target.Position[0], (int)target.Position[1]);
+            Vector<float>? targetPosition = World.GetFreeAdjacentLocation((int)target.Position.X, (int)target.Position.Y);
             if (targetPosition != null)
                 parent.Owner.MoveTowardsPosition(targetPosition.Value);
             else
@@ -111,7 +111,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
         /// <returns></returns>
         private MiningMarker LocateValidMarker(PawnBehaviour parent)
         {
-            foreach (Marker marker in World.GetSprialMarkers((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 60))
+            foreach (Marker marker in World.GetSprialMarkers((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 60))
             {
                 if (!(marker is MiningMarker))
                     continue;
@@ -122,7 +122,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                 if (marker.IsClaimed || marker.Destroyed)
                     continue;
                 //Is the marker completed surrounded?
-                if (World.IsLocationFullyEnclosed((int)marker.Position[0], (int)marker.Position[1]))
+                if (World.IsLocationFullyEnclosed((int)marker.Position.X, (int)marker.Position.Y))
                     continue;
                 //Return the marker
                 return marker as MiningMarker;

--- a/GJ2022/PawnBehaviours/PawnActions/SmeltOre.cs
+++ b/GJ2022/PawnBehaviours/PawnActions/SmeltOre.cs
@@ -34,7 +34,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
         {
             if (parent.Owner.InCrit)
                 return false;
-            if (World.HasThingInRange("Furnace", (int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 20, (List<IComponentHandler> area) =>
+            if (World.HasThingInRange("Furnace", (int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 20, (List<IComponentHandler> area) =>
             {
                 foreach (IComponentHandler structure in area)
                 {
@@ -46,7 +46,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
                 }
                 return false;
             })
-                && World.HasItemsInRange((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 40, (List<Item> toCheck) =>
+                && World.HasItemsInRange((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 40, (List<Item> toCheck) =>
                 {
                     foreach (Item item in toCheck)
                     {
@@ -183,7 +183,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
 
         private Entity LocateValidFurnace(PawnBehaviour parent)
         {
-            foreach (Entity structure in World.GetSpiralThings<Entity>("Furnace", (int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 20))
+            foreach (Entity structure in World.GetSpiralThings<Entity>("Furnace", (int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 20))
             {
                 //If we marked this location as unreachable, ignore it.
                 if (unreachableLocations.Contains(structure.Position))
@@ -205,7 +205,7 @@ namespace GJ2022.PawnBehaviours.PawnActions
         /// </summary>
         private IronOre LocateMaterials(PawnBehaviour parent)
         {
-            foreach (Item item in World.GetSprialItems((int)parent.Owner.Position[0], (int)parent.Owner.Position[1], 40))
+            foreach (Item item in World.GetSprialItems((int)parent.Owner.Position.X, (int)parent.Owner.Position.Y, 40))
             {
                 //If we marked this location as unreachable, ignore it.
                 if (unreachableLocations.Contains(item.Position))

--- a/GJ2022/Rendering/Camera.cs
+++ b/GJ2022/Rendering/Camera.cs
@@ -99,10 +99,10 @@ namespace GJ2022.Rendering
             //ProjectionMatrix = Matrix.Identity[4];
             //ViewMatrix = Matrix.GetTranslationMatrix(3 * (float)Math.Sin(Glfw.Time), 3 * (float)Math.Cos(Glfw.Time), -5);
             //ViewMatrix = Matrix.GetTranslationMatrix((float)Math.Sin(Glfw.Time) * 5.0f, (float)Math.Cos(Glfw.Time) * 5.0f, 0);
-            ViewMatrix = Matrix.GetScaleMatrix(Scale[0], Scale[1], Scale[2]) * Matrix.GetTranslationMatrix(Position[0], Position[1], Position[2]);
+            ViewMatrix = Matrix.GetScaleMatrix(Scale[0], Scale[1], Scale[2]) * Matrix.GetTranslationMatrix(Position.X, Position.Y, Position.Z);
 
             //Update audio
-            AudioMaster.UpdateListener(Position[0], Position[1], 0);
+            AudioMaster.UpdateListener(Position.X, Position.Y, 0);
 
         }
 

--- a/GJ2022/Rendering/RenderSystems/BlueprintRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/BlueprintRenderSystem.cs
@@ -40,9 +40,9 @@ namespace GJ2022.Rendering.RenderSystems
                 case 0:
                     Vector<float> position = targetItem.GetPosition();
                     return new float[] {
-                        position[0],
-                        position[1],
-                        position[2]
+                        position.X,
+                        position.Y,
+                        position.Z
                     };
                 case 1:
                     RendererTextureData texData = targetItem.GetRendererTextureData();

--- a/GJ2022/Rendering/RenderSystems/ButtonRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/ButtonRenderSystem.cs
@@ -30,8 +30,8 @@ namespace GJ2022.Rendering.RenderSystems
                 case 0:
                     Vector<float> position = targetItem.Position;
                     return new float[] {
-                        position[0],
-                        position[1],
+                        position.X,
+                        position.Y,
                         targetItem.Layer,
                         (float)targetItem.PositionMode,
                     };

--- a/GJ2022/Rendering/RenderSystems/CircleRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/CircleRenderSystem.cs
@@ -40,9 +40,9 @@ namespace GJ2022.Rendering.RenderSystems
                 case 0:
                     Vector<float> position = targetItem.GetPosition();
                     return new float[] {
-                        position[0],
-                        position[1],
-                        position[2]
+                        position.X,
+                        position.Y,
+                        position.Z
                     };
                 case 1:
                     return new float[] {

--- a/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/InstanceRenderSystem.cs
@@ -45,9 +45,9 @@ namespace GJ2022.Rendering.RenderSystems
                 case 0:
                     Vector<float> position = targetItem.GetPosition();
                     return new float[] {
-                        position[0],
-                        position[1],
-                        position[2]
+                        position.X,
+                        position.Y,
+                        position.Z
                     };
                 case 1:
                     return new float[] {

--- a/GJ2022/Rendering/RenderSystems/Renderables/BlueprintRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/BlueprintRenderable.cs
@@ -59,8 +59,8 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetPosition(Vector<float> position)
         {
-            _position[0] = position[0];
-            _position[1] = position[1];
+            _position.X = position.X;
+            _position.Y = position.Y;
             //Update position in renderer
             if (renderableBatchIndex.Count > 0)
                 (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<IBlueprintRenderable, BlueprintRenderSystem>)?.UpdateBatchData(this, 0);
@@ -71,7 +71,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetLayer(float layer)
         {
-            _position[2] = layer;
+            _position.Z = layer;
             //Update position in renderer
             if (renderableBatchIndex.Count > 0)
                 (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<IBlueprintRenderable, BlueprintRenderSystem>)?.UpdateBatchData(this, 0);

--- a/GJ2022/Rendering/RenderSystems/Renderables/ButtonRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/ButtonRenderable.cs
@@ -87,8 +87,8 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetPosition(Vector<float> position)
         {
-            _position[0] = position[0];
-            _position[1] = position[1];
+            _position.X = position.X;
+            _position.Y = position.Y;
             //Update position in renderer
             if (renderableBatchIndex.Count > 0)
                 (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<IButtonRenderable, ButtonRenderSystem>)?.UpdateBatchData(this, 0);

--- a/GJ2022/Rendering/RenderSystems/Renderables/CircleRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/CircleRenderable.cs
@@ -62,8 +62,8 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetPosition(Vector<float> position)
         {
-            _position[0] = position[0];
-            _position[1] = position[1];
+            _position.X = position.X;
+            _position.Y = position.Y;
             //Update position in renderer
             if (renderableBatchIndex.Count > 0)
                 (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<ICircleRenderable, CircleRenderSystem>)?.UpdateBatchData(this, 0);
@@ -74,7 +74,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetLayer(float layer)
         {
-            _position[2] = layer;
+            _position.Z = layer;
             //Update position in renderer
             if (renderableBatchIndex.Count > 0)
                 (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<ICircleRenderable, CircleRenderSystem>)?.UpdateBatchData(this, 0);

--- a/GJ2022/Rendering/RenderSystems/Renderables/StandardRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/StandardRenderable.cs
@@ -117,8 +117,8 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetPosition(Vector<float> position)
         {
-            _position[0] = position[0];
-            _position[1] = position[1];
+            _position.X = position.X;
+            _position.Y = position.Y;
             //Update position in renderer
             lock (renderableBatchIndex)
                 if (renderableBatchIndex.Count > 0)
@@ -134,7 +134,7 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetLayer(float layer)
         {
-            _position[2] = layer;
+            _position.Z = layer;
             //Update position in renderer
             lock (renderableBatchIndex)
                 if (renderableBatchIndex.Count > 0)

--- a/GJ2022/Rendering/RenderSystems/Renderables/UserInterfaceRenderable.cs
+++ b/GJ2022/Rendering/RenderSystems/Renderables/UserInterfaceRenderable.cs
@@ -72,8 +72,8 @@ namespace GJ2022.Rendering.RenderSystems.Renderables
         /// </summary>
         private void SetPosition(Vector<float> position)
         {
-            _position[0] = position[0];
-            _position[1] = position[1];
+            _position.X = position.X;
+            _position.Y = position.Y;
             //Update position in renderer
             if (renderableBatchIndex.Count > 0)
                 (renderableBatchIndex.Keys.ElementAt(0) as RenderBatchSet<IUserInterfaceRenderable, UserInterfaceRenderSystem>)?.UpdateBatchData(this, 0);

--- a/GJ2022/Rendering/RenderSystems/TextRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/TextRenderSystem.cs
@@ -54,8 +54,8 @@ namespace GJ2022.Rendering.RenderSystems
                 case 0:
                     Vector<float> position = targetItem.Position;
                     return new float[] {
-                        position[0],
-                        position[1],
+                        position.X,
+                        position.Y,
                         Layers.LAYER_TEXT,
                         (float)targetItem.PositionMode
                     };

--- a/GJ2022/Rendering/RenderSystems/UserInterfaceRenderSystem.cs
+++ b/GJ2022/Rendering/RenderSystems/UserInterfaceRenderSystem.cs
@@ -31,8 +31,8 @@ namespace GJ2022.Rendering.RenderSystems
                 case 0:
                     Vector<float> position = targetItem.Position;
                     return new float[] {
-                        position[0],
-                        position[1],
+                        position.X,
+                        position.Y,
                         targetItem.Layer,
                         (float)targetItem.PositionMode
                     };

--- a/GJ2022/Subsystems/PathfindingSystem.cs
+++ b/GJ2022/Subsystems/PathfindingSystem.cs
@@ -201,25 +201,25 @@ namespace GJ2022.Subsystems
             ConnectingDirections connectingDirections = 0;
             //Check north
             if (!IsPointChecked(processData, position + new Vector<int>(0, 1), ConnectingDirections.NORTH_SOUTH, ignoringHazards)
-                    && position[1] < processData.MaximumY
+                    && position.Y < processData.MaximumY
                     && !World.IsSolid(position + new Vector<int>(0, 1))
                     && HazardCheck(ignoringHazards, position, source, ConnectingDirections.NORTH))
                 connectingDirections |= ConnectingDirections.NORTH;
             //Check east
             if (!IsPointChecked(processData, position + new Vector<int>(1, 0), ConnectingDirections.EAST_WEST, ignoringHazards)
-                    && position[0] < processData.MaximumX
+                    && position.X < processData.MaximumX
                     && !World.IsSolid(position + new Vector<int>(1, 0))
                     && HazardCheck(ignoringHazards, position, source, ConnectingDirections.EAST))
                 connectingDirections |= ConnectingDirections.EAST;
             //Check south
             if (!IsPointChecked(processData, position + new Vector<int>(0, -1), ConnectingDirections.NORTH_SOUTH, ignoringHazards)
-                    && position[1] > processData.MinimumY
+                    && position.Y > processData.MinimumY
                     && !World.IsSolid(position + new Vector<int>(0, -1))
                     && HazardCheck(ignoringHazards, position, source, ConnectingDirections.SOUTH))
                 connectingDirections |= ConnectingDirections.SOUTH;
             //Check west
             if (!IsPointChecked(processData, position + new Vector<int>(-1, 0), ConnectingDirections.EAST_WEST, ignoringHazards)
-                    && position[0] > processData.MinimumX
+                    && position.X > processData.MinimumX
                     && !World.IsSolid(position + new Vector<int>(-1, 0))
                     && HazardCheck(ignoringHazards, position, source, ConnectingDirections.WEST))
                 connectingDirections |= ConnectingDirections.WEST;
@@ -254,7 +254,7 @@ namespace GJ2022.Subsystems
             if ((ignoringHazards & PawnHazards.HAZARD_LOW_PRESSURE) != 0)
                 return true;
             //Check for pressure (50 should be safe)
-            return World.GetTurf(position[0], position[1])?.Atmosphere?.ContainedAtmosphere?.KiloPascalPressure > 50;
+            return World.GetTurf(position.X, position.Y)?.Atmosphere?.ContainedAtmosphere?.KiloPascalPressure > 50;
         }
 
         private bool BreathCheck(PawnHazards ignoringHazards, Vector<int> position, Vector<int> source, ConnectingDirections direction)
@@ -263,7 +263,7 @@ namespace GJ2022.Subsystems
             if ((ignoringHazards & PawnHazards.HAZARD_BREATH) != 0)
                 return true;
             //Check air
-            if (World.GetTurf(position[0], position[1])?.Atmosphere?.ContainedAtmosphere?.GetMoles(Oxygen.Singleton) > 0.02f)
+            if (World.GetTurf(position.X, position.Y)?.Atmosphere?.ContainedAtmosphere?.GetMoles(Oxygen.Singleton) > 0.02f)
                 return true;
             //Area has no air
             return false;
@@ -278,8 +278,8 @@ namespace GJ2022.Subsystems
             if (World.HasGravity(position))
                 return true;
             //We can move in a straight line without gravity
-            int delta_x = position[0] - source[0];
-            int delta_y = position[1] - source[1];
+            int delta_x = position.X - source[0];
+            int delta_y = position.Y - source[1];
             //If the direction is north or south and we want to move vertically, allow it
             if (delta_x == 0 && (direction & ConnectingDirections.NORTH_SOUTH) != 0)
                 return true;

--- a/GJ2022/Subsystems/PawnControllerSystem.cs
+++ b/GJ2022/Subsystems/PawnControllerSystem.cs
@@ -30,7 +30,7 @@ namespace GJ2022.Subsystems
         public static void QueueBlueprint(Vector<float> position, Blueprint blueprint, int layer)
         {
             //Check if the blueprint is redundant
-            if (World.GetTurf((int)position[0], (int)position[1])?.GetType() == blueprint.BlueprintDetail.CreatedType)
+            if (World.GetTurf((int)position.X, (int)position.Y)?.GetType() == blueprint.BlueprintDetail.CreatedType)
             {
                 blueprint.Destroy();
                 return;

--- a/GJ2022/UserInterface/Components/Advanced/UserInterfaceDropdown.cs
+++ b/GJ2022/UserInterface/Components/Advanced/UserInterfaceDropdown.cs
@@ -78,14 +78,14 @@ namespace GJ2022.UserInterface.Components.Advanced
             if (settings.OpenToSide)
             {
                 //We open to the side
-                component.Position = new Vector<float>(Position[0] + (settings.Scale[0] + component.Scale[0]) * 0.5f, Position[1] + cachedHeight);
+                component.Position = new Vector<float>(Position.X + (settings.Scale[0] + component.Scale[0]) * 0.5f, Position.Y + cachedHeight);
                 cachedHeight += component.Scale[1];
             }
             else
             {
                 //We open above.
                 cachedHeight += component.Scale[1];
-                component.Position = new Vector<float>(Position[0], Position[1] + cachedHeight);
+                component.Position = new Vector<float>(Position.X, Position.Y + cachedHeight);
             }
             //Hide components if the dropdown is toggled off.
             if (!toggled)
@@ -115,14 +115,14 @@ namespace GJ2022.UserInterface.Components.Advanced
                 if (settings.OpenToSide)
                 {
                     //We open to the side
-                    component.Position = new Vector<float>(Position[0] + (settings.Scale[0] + component.Scale[0]) * 0.5f, Position[1] + cachedHeight);
+                    component.Position = new Vector<float>(Position.X + (settings.Scale[0] + component.Scale[0]) * 0.5f, Position.Y + cachedHeight);
                     cachedHeight += component.Scale[1];
                 }
                 else
                 {
                     //We open above.
                     cachedHeight += component.Scale[1];
-                    component.Position = new Vector<float>(Position[0], Position[1] + cachedHeight);
+                    component.Position = new Vector<float>(Position.X, Position.Y + cachedHeight);
                 }
             }
         }

--- a/GJ2022/UserInterface/Components/UserInterfaceButton.cs
+++ b/GJ2022/UserInterface/Components/UserInterfaceButton.cs
@@ -23,9 +23,9 @@ namespace GJ2022.UserInterface.Components
 
         public CursorSpace PositionSpace { get; } = CursorSpace.SCREEN_SPACE;
 
-        public float WorldX => _position[0] * (1080.0f / 1920.0f) - Width / 2;
+        public float WorldX => _position.X * (1080.0f / 1920.0f) - Width / 2;
 
-        public float WorldY => -_position[1] - Height / 2;
+        public float WorldY => -_position.Y - Height / 2;
 
         public float Width => Scale[0] * (1080.0f / 1920.0f);
 

--- a/GJ2022/Utility/Helpers/WorldToScreenHelper.cs
+++ b/GJ2022/Utility/Helpers/WorldToScreenHelper.cs
@@ -9,8 +9,8 @@ namespace GJ2022.Utility.Helpers
 
         public static Vector<float> GetScreenCoordinates(Window window, Vector<float> worldPosition)
         {
-            float worldX = worldPosition[0];
-            float worldY = worldPosition[1];
+            float worldX = worldPosition.X;
+            float worldY = worldPosition.Y;
             //Guess
             Matrix cameraMatrix = RenderMaster.mainCamera.ProjectionMatrix * RenderMaster.mainCamera.ViewMatrix;
             float translationX = cameraMatrix[4, 1];

--- a/GJ2022/Utility/MathConstructs/Vector.cs
+++ b/GJ2022/Utility/MathConstructs/Vector.cs
@@ -24,6 +24,23 @@ namespace GJ2022.Utility.MathConstructs
             set { Values[x] = value; }
         }
 
+        public T X {
+            get => Values[0];
+            set => Values[0] = value;
+        }
+
+        public T Y
+        {
+            get => Values[1];
+            set => Values[1] = value;
+        }
+
+        public T Z
+        {
+            get => Values[2];
+            set => Values[2] = value;
+        }
+
         /// <summary>
         /// Gets the dimensions of the vector
         /// </summary>


### PR DESCRIPTION
Cleans up vectors, adds in .X, .Y and .Z which correspond directly to using [0], [1] and [2].
Just makes them a bit easier to read and is cleaner in general.
```
Position[0] = x...
```
New:
```
Position.X = x...
```