### PR TITLE
AudioMaster will no longer crash the entire program if the audio library is not found.

### DIFF
--- a/GJ2022.Tests/EntityDefTest.cs
+++ b/GJ2022.Tests/EntityDefTest.cs
@@ -15,6 +15,8 @@ namespace GJ2022.Tests
         [TestMethod]
         public void TestDefs()
         {
+            //Reset for testing purposes
+            Log.ExceptionCount = 0;
             EntityLoader.LoadEntities();
             if (Log.ExceptionCount > 0)
                 Assert.Fail();

--- a/GJ2022/Audio/AudioSource.cs
+++ b/GJ2022/Audio/AudioSource.cs
@@ -10,6 +10,8 @@ namespace GJ2022.Audio
 
         public void PlaySound(string file, float x, float y, float z = 0, float gain = 1.0f, bool repeating = false)
         {
+            if (!AudioMaster.UsingAudio)
+                return;
             //Get the AL API
             AL al = AL.GetApi();
             //Get the audio file

--- a/GJ2022/Program.cs
+++ b/GJ2022/Program.cs
@@ -65,7 +65,15 @@ namespace GJ2022
             TextureCache.LoadTextureDataJson();
 
             //Setup open AL
-            AudioMaster.Initialize();
+            try
+            {
+                AudioMaster.Initialize();
+            }
+            catch (System.TypeInitializationException e)
+            {
+                Log.WriteLine("===FAILED TO LOAD AUDIO===", LogType.ERROR);
+                Log.WriteLine(e, LogType.ERROR);
+            }
             //new AudioSource().PlaySound("effects/picaxe1.wav", 0, 0, repeating: true);
             //new AudioSource().PlaySound("effects/picaxe1.wav", 0, -60, repeating: true);
 


### PR DESCRIPTION
If openAL.dll is not found for whatever reason then the program will handle it and not play audio instead of crashing.